### PR TITLE
feat(mobile): Added the profile tab, friends screen, and settings screen

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,6 +1,5 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { Icon, Label, NativeTabs, VectorIcon } from 'expo-router/unstable-native-tabs';
-
 export const unstable_settings = {
   anchor: 'map',
 };

--- a/apps/mobile/src/app/(tabs)/profile/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/friends.tsx
@@ -1,12 +1,30 @@
-import { ScrollView, Text } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useRouter } from 'expo-router';
+import { ScrollView, Text, TouchableOpacity } from 'react-native';
 
 export default function FriendsScreen() {
+  const router = useRouter();
+
   return (
     <ScrollView
       className="flex-1 bg-app-background"
       contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={{ flexGrow: 1, padding: 24, rowGap: 8 }}
+      contentContainerStyle={{ flexGrow: 1, padding: 24, paddingTop: 110, rowGap: 8 }}
     >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+        onPress={() => (router.canGoBack() ? router.back() : router.push('/profile'))}
+        style={{
+          alignSelf: 'flex-start',
+          width: 44,
+          height: 44,
+          justifyContent: 'center',
+          marginTop: -60,
+        }}
+      >
+        <MaterialIcons name="arrow-back" size={30} color="#ff8420" />
+      </TouchableOpacity>
       <Text className="text-[30px] font-bold leading-8 text-app-text">Friends</Text>
       <Text className="text-base leading-6 text-app-text">
         Friends list, requests, and suggestions will appear here.

--- a/apps/mobile/src/app/(tabs)/profile/index.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/index.tsx
@@ -1,25 +1,279 @@
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import PostGrid from '@/components/ui/PostGrid';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useRouter } from 'expo-router';
-import { Text, View } from 'react-native';
+import { useState } from 'react';
+import { Image, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { Button, ButtonText } from '@/components/ui/button';
+const placeholderImage = '@/assets/images/icon.png';
 
 export default function ProfileScreen() {
-  const router = useRouter();
+  const { push } = useRouter();
+  const [activeTab, setActiveTab] = useState<'all' | 'recent' | 'tagged'>('all');
+
+  // Sample post data for "All" tab
+  const allPosts = Array.from({ length: 12 }, (_, i) => ({
+    id: i,
+    image: require(placeholderImage),
+    comments: ['Great post!', 'Love this!', 'Amazing!'],
+  }));
+
+  // Sample post data for "Recent" tab
+  const recentPosts = Array.from({ length: 6 }, (_, i) => ({
+    id: `recent-${i}`,
+    image: require(placeholderImage),
+    comments: ['Just posted!', 'Fresh content!', 'Love it!'],
+  }));
+
+  // Sample post data for "Tagged" tab
+  const taggedPosts = Array.from({ length: 4 }, (_, i) => ({
+    id: `tagged-${i}`,
+    image: require(placeholderImage),
+    comments: ['Tagged in this!', 'Amazing moment!', 'Great shot!'],
+  }));
 
   return (
-    <View className="flex-1 items-center justify-center gap-3 bg-app-background p-6">
-      <Text className="text-[30px] font-bold leading-8 text-app-text">Profile</Text>
-      <Text className="text-center text-base leading-6 text-app-text">
-        Account, preferences, and friends will live here.
-      </Text>
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Open settings"
+          onPress={() => push('/profile/settings')}
+          style={styles.settingsButton}
+        >
+          <MaterialIcons name="settings" size={22} color="#ff8420" />
+        </TouchableOpacity>
 
-      <Button variant="secondary" className="mt-2" onPress={() => router.push('/profile/friends')}>
-        <ButtonText variant="secondary">Friends</ButtonText>
-      </Button>
+        {/* Profile Header */}
+        <ThemedView style={styles.header}>
+          {/* Profile Picture */}
+          <View style={styles.profilePicContainer}>
+            <Image source={require(placeholderImage)} style={styles.profilePic} />
+          </View>
 
-      <Button variant="secondary" className="mt-2" onPress={() => router.push('/profile/settings')}>
-        <ButtonText variant="secondary">Settings</ButtonText>
-      </Button>
-    </View>
+          {/* Name and Bio */}
+          <View style={styles.nameBioContainer}>
+            <ThemedText style={styles.username}>Pandamanawesome</ThemedText>
+            <ThemedText style={styles.bio}>
+              WOOOOO FOMO✨
+              {'\n'}Bazinga!
+            </ThemedText>
+          </View>
+        </ThemedView>
+
+        {/* Profile Info */}
+        <ThemedView style={styles.infoContainer}>
+          {/* Stats */}
+          <View style={styles.statsContainer}>
+            <View style={styles.stat}>
+              <ThemedText style={styles.statNumber}>42</ThemedText>
+              <ThemedText style={styles.statLabel}>Posts</ThemedText>
+            </View>
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessibilityLabel="Open friends"
+              onPress={() => push('/profile/friends')}
+              style={styles.stat}
+            >
+              <ThemedText style={styles.statNumber}>180</ThemedText>
+              <ThemedText style={styles.statLabel}>Friends</ThemedText>
+            </TouchableOpacity>
+          </View>
+        </ThemedView>
+
+        {/* Action Buttons */}
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity style={styles.RecentActivityButton}>
+            <ThemedText style={styles.RecentActivityButtonText}>Recent Activity</ThemedText>
+          </TouchableOpacity>
+        </View>
+
+        {/* Stories/Highlights */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.highlightsContainer}
+          contentContainerStyle={styles.highlightsContent}
+        ></ScrollView>
+
+        {/* Tab Bar */}
+        <View style={styles.tabBar}>
+          <TouchableOpacity
+            style={[styles.tab, activeTab === 'all' && styles.activeTab]}
+            onPress={() => setActiveTab('all')}
+          >
+            <ThemedText>All</ThemedText>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.tab, activeTab === 'recent' && styles.activeTab]}
+            onPress={() => setActiveTab('recent')}
+          >
+            <ThemedText>Recent</ThemedText>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.tab, activeTab === 'tagged' && styles.activeTab]}
+            onPress={() => setActiveTab('tagged')}
+          >
+            <ThemedText>Tagged</ThemedText>
+          </TouchableOpacity>
+        </View>
+
+        {/* Posts Grid Component - Changes based on active tab */}
+        {activeTab === 'all' && <PostGrid posts={allPosts} />}
+        {activeTab === 'recent' && <PostGrid posts={recentPosts} />}
+        {activeTab === 'tagged' && <PostGrid posts={taggedPosts} />}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  contentContainer: {
+    paddingTop: 10,
+  },
+  header: {
+    flexDirection: 'row',
+    padding: 16,
+    paddingTop: 24,
+    alignItems: 'center',
+  },
+  settingsButton: {
+    position: 'absolute',
+    top: 12,
+    right: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: '#ffa600',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 10,
+    backgroundColor: '#fff',
+  },
+  profilePicContainer: {
+    width: 100,
+    height: 100,
+    backgroundColor: '#ff8420',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderColor: '#ffa600',
+    borderRadius: 10,
+    borderWidth: 3,
+    marginRight: 16,
+    overflow: 'hidden',
+  },
+  profilePic: {
+    width: '100%',
+    height: '100%',
+  },
+  statsContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+  stat: {
+    alignItems: 'center',
+  },
+  statNumber: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  statLabel: {
+    fontSize: 12,
+  },
+  nameBioContainer: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  infoContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  username: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  bio: {
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
+  RecentActivityButton: {
+    flex: 1,
+    height: 82,
+    borderWidth: 1,
+    borderColor: '#ffa600',
+    borderRadius: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 8,
+  },
+  RecentActivityButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  shareButton: {
+    width: 40,
+    height: 32,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  highlightsContainer: {
+    marginBottom: 16,
+  },
+  highlightsContent: {
+    paddingHorizontal: 16,
+  },
+  highlight: {
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  highlightRing: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  highlightText: {
+    fontSize: 12,
+  },
+  tabBar: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    borderTopColor: '#ddd',
+    borderBottomWidth: 1,
+    borderBottomColor: '#ddd',
+  },
+  tab: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  activeTab: {
+    borderBottomWidth: 5,
+    borderBottomColor: '#ffa600',
+  },
+});

--- a/apps/mobile/src/app/feed/[h3Id].tsx
+++ b/apps/mobile/src/app/feed/[h3Id].tsx
@@ -1,19 +1,19 @@
-import { Stack, useLocalSearchParams } from 'expo-router';
-import { ScrollView, Text } from 'react-native';
+// import { Stack, useLocalSearchParams } from 'expo-router';
+// import { ScrollView, Text } from 'react-native';
 
-export default function FeedModal() {
-  const { h3Id } = useLocalSearchParams<{ h3Id: string }>();
+// export default function FeedModal() {
+//   const { h3Id } = useLocalSearchParams<{ h3Id: string }>();
 
-  return (
-    <ScrollView
-      className="flex-1 bg-app-background"
-      contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={{ flexGrow: 1, padding: 24, rowGap: 12 }}
-    >
-      <Stack.Screen options={{ title: 'Feed' }} />
-      <Text className="text-base leading-6 text-app-text">
-        Showing posts/events for H3 cell: <Text className="font-semibold">{h3Id ?? 'unknown'}</Text>
-      </Text>
-    </ScrollView>
-  );
-}
+//   return (
+//     <ScrollView
+//       className="flex-1 bg-app-background"
+//       contentInsetAdjustmentBehavior="automatic"
+//       contentContainerStyle={{ flexGrow: 1, padding: 24, rowGap: 12 }}
+//     >
+//       <Stack.Screen options={{ title: 'Feed' }} />
+//       <Text className="text-base leading-6 text-app-text">
+//         Showing posts/events for H3 cell: <Text className="font-semibold">{h3Id ?? 'unknown'}</Text>
+//       </Text>
+//     </ScrollView>
+//   );
+// }

--- a/apps/mobile/src/components/themed-text.tsx
+++ b/apps/mobile/src/components/themed-text.tsx
@@ -1,0 +1,60 @@
+import { StyleSheet, Text, type TextProps } from 'react-native';
+
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+export type ThemedTextProps = TextProps & {
+  lightColor?: string;
+  darkColor?: string;
+  type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link';
+};
+
+export function ThemedText({
+  style,
+  lightColor,
+  darkColor,
+  type = 'default',
+  ...rest
+}: ThemedTextProps) {
+  const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
+
+  return (
+    <Text
+      style={[
+        { color },
+        type === 'default' ? styles.default : undefined,
+        type === 'title' ? styles.title : undefined,
+        type === 'defaultSemiBold' ? styles.defaultSemiBold : undefined,
+        type === 'subtitle' ? styles.subtitle : undefined,
+        type === 'link' ? styles.link : undefined,
+        style,
+      ]}
+      {...rest}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  default: {
+    fontSize: 16,
+    lineHeight: 24,
+  },
+  defaultSemiBold: {
+    fontSize: 16,
+    lineHeight: 24,
+    fontWeight: '600',
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    lineHeight: 32,
+  },
+  subtitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  link: {
+    lineHeight: 30,
+    fontSize: 16,
+    color: '#0a7ea4',
+  },
+});

--- a/apps/mobile/src/components/themed-view.tsx
+++ b/apps/mobile/src/components/themed-view.tsx
@@ -1,0 +1,14 @@
+import { View, type ViewProps } from 'react-native';
+
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+export type ThemedViewProps = ViewProps & {
+  lightColor?: string;
+  darkColor?: string;
+};
+
+export function ThemedView({ style, lightColor, darkColor, ...otherProps }: ThemedViewProps) {
+  const backgroundColor = useThemeColor({ light: lightColor, dark: darkColor }, 'background');
+
+  return <View style={[{ backgroundColor }, style]} {...otherProps} />;
+}

--- a/apps/mobile/src/components/top-bar.tsx
+++ b/apps/mobile/src/components/top-bar.tsx
@@ -1,0 +1,37 @@
+import { StyleSheet } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+export type TopBarProps = {
+  title?: string;
+  style?: any;
+};
+
+export function TopBar({ title, style }: TopBarProps) {
+  const backgroundColor = useThemeColor({}, 'background');
+  const textColor = useThemeColor({}, 'text');
+
+  return (
+    <ThemedView style={[styles.container, { backgroundColor }, style]}>
+      {title && <ThemedText style={[styles.title, { color: textColor }]}>{'fomo'}</ThemedText>}
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingVertical: 20,
+    borderBottomWidth: 4,
+    borderBottomColor: '#eebd54',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    textAlign: 'center',
+    textAlignVertical: 'bottom',
+    paddingTop: 40,
+  },
+});

--- a/apps/mobile/src/components/ui/Billboard.tsx
+++ b/apps/mobile/src/components/ui/Billboard.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { ImageBackground, StyleSheet } from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+
+// Simple billboard component that renders a background image (default or passed-in)
+// and lays out any children on top. This allows the parent to position clickable
+// ads of arbitrary size on the billboard surface.
+
+import { StyleProp, View, ViewStyle } from 'react-native';
+
+interface BillboardProps {
+  /** Optional custom background image for the billboard */
+  backgroundImage?: any;
+  /** Children elements rendered on top of the background */
+  children?: React.ReactNode;
+  /** Style applied to the container that wraps children (defaults to full size) */
+  overlayStyle?: StyleProp<ViewStyle>;
+}
+
+const defaultBackground = require('@/assets/images/billboard_background.png');
+
+const Billboard: React.FC<BillboardProps> = ({
+  backgroundImage = defaultBackground,
+  children,
+  overlayStyle,
+}) => {
+  return (
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.container} edges={['left', 'right']}>
+        <ImageBackground source={backgroundImage} resizeMode="cover" style={styles.image}>
+          {/* overlay view ensures callers can absolutely position multiple
+              ad elements without needing to wrap themselves */}
+          <View style={[styles.overlay, overlayStyle]}>{children}</View>
+        </ImageBackground>
+      </SafeAreaView>
+    </SafeAreaProvider>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  image: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});
+
+export default Billboard;

--- a/apps/mobile/src/components/ui/PostGrid.tsx
+++ b/apps/mobile/src/components/ui/PostGrid.tsx
@@ -1,0 +1,62 @@
+import { useRouter } from 'expo-router';
+import React from 'react';
+import { FlatList, Image, StyleSheet, TouchableOpacity } from 'react-native';
+
+interface Post {
+  id: string | number;
+  image: any;
+  comments?: string[];
+}
+
+interface PostGridProps {
+  posts: Post[];
+}
+
+const PostGrid = ({ posts }: PostGridProps) => {
+  const router = useRouter();
+
+  const handlePostPress = (post: Post) => {
+    router.push({
+      pathname: '../screens/PostDetailScreen',
+      params: { postId: post.id, post: JSON.stringify(post) },
+    });
+  };
+
+  const renderItem = ({ item }: { item: Post }) => (
+    <TouchableOpacity onPress={() => handlePostPress(item)} style={styles.gridItem}>
+      <Image source={item.image} style={styles.gridImage} />
+    </TouchableOpacity>
+  );
+
+  return (
+    <FlatList
+      data={posts}
+      renderItem={renderItem}
+      keyExtractor={(item) => item.id.toString()}
+      numColumns={3}
+      scrollEnabled={false}
+      contentContainerStyle={styles.grid}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+  },
+  gridItem: {
+    width: '33.333%',
+    aspectRatio: 1,
+    borderWidth: 0.5,
+    borderColor: '#ddd',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  gridImage: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+  },
+});
+
+export default PostGrid;

--- a/apps/mobile/src/constants/theme.ts
+++ b/apps/mobile/src/constants/theme.ts
@@ -1,0 +1,53 @@
+/**
+ * Below are the colors that are used in the app. The colors are defined in the light and dark mode.
+ * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
+ */
+
+import { Platform } from 'react-native';
+
+const tintColorLight = '#0a7ea4';
+const tintColorDark = '#fff';
+
+export const Colors = {
+  light: {
+    text: '#11181C',
+    background: '#fff',
+    tint: tintColorLight,
+    icon: '#687076',
+    tabIconDefault: '#687076',
+    tabIconSelected: tintColorLight,
+  },
+  dark: {
+    text: '#ECEDEE',
+    background: '#151718',
+    tint: tintColorDark,
+    icon: '#9BA1A6',
+    tabIconDefault: '#9BA1A6',
+    tabIconSelected: tintColorDark,
+  },
+};
+
+export const Fonts = Platform.select({
+  ios: {
+    /** iOS `UIFontDescriptorSystemDesignDefault` */
+    sans: 'system-ui',
+    /** iOS `UIFontDescriptorSystemDesignSerif` */
+    serif: 'ui-serif',
+    /** iOS `UIFontDescriptorSystemDesignRounded` */
+    rounded: 'ui-rounded',
+    /** iOS `UIFontDescriptorSystemDesignMonospaced` */
+    mono: 'ui-monospace',
+  },
+  default: {
+    sans: 'normal',
+    serif: 'serif',
+    rounded: 'normal',
+    mono: 'monospace',
+  },
+  web: {
+    sans: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+    serif: "Georgia, 'Times New Roman', serif",
+    rounded: "'SF Pro Rounded', 'Hiragino Maru Gothic ProN', Meiryo, 'MS PGothic', sans-serif",
+    mono: "SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+  },
+});

--- a/apps/mobile/src/hooks/use-theme-color.ts
+++ b/apps/mobile/src/hooks/use-theme-color.ts
@@ -1,0 +1,21 @@
+/**
+ * Learn more about light and dark modes:
+ * https://docs.expo.dev/guides/color-schemes/
+ */
+
+import { Colors } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export function useThemeColor(
+  props: { light?: string; dark?: string },
+  colorName: keyof typeof Colors.light & keyof typeof Colors.dark
+) {
+  const theme = useColorScheme() ?? 'light';
+  const colorFromProps = props[theme];
+
+  if (colorFromProps) {
+    return colorFromProps;
+  } else {
+    return Colors[theme][colorName];
+  }
+}


### PR DESCRIPTION
- Added a settings cog icon on the Profile screen (top-right) that navigates to the Settings screen.
- Made the Friends stat on Profile tappable and routed it to the Friends screen.
- Removed the global custom top bar for tabs so Profile and related screens use the intended in-screen UI.
- Improved vertical spacing on Profile so content sits lower and feels less cramped at the top.

<img width="825" height="1002" alt="mermaid-diagram" src="https://github.com/user-attachments/assets/c443b011-6688-478b-96fd-a42ca743e211" />
