### PR TITLE
add timed-based freshness to friend recommendations

### DIFF
--- a/packages/backend/convex/friendRecs.ts
+++ b/packages/backend/convex/friendRecs.ts
@@ -19,11 +19,13 @@ export const upsert = mutation({
     if (existing) {
       await ctx.db.patch(existing._id, {
         recs: args.recs,
+        updatedAt: Date.now(),
       });
     } else {
       await ctx.db.insert('friendRecs', {
         userId: args.userId,
         recs: args.recs,
+        updatedAt: Date.now(),
       });
     }
   },

--- a/packages/backend/convex/query.ts
+++ b/packages/backend/convex/query.ts
@@ -53,3 +53,29 @@ export const friend_exists = query({
     return null;
   },
 });
+
+// Retrieves friend recommendations for a user.
+// Also determines whether the recommendations are "fresh"
+// based on a 24-hour time window.
+export const getFriendRecs = query({
+  args: { userId: v.id('users') },
+  handler: async (ctx, { userId }) => {
+    const rec = await ctx.db
+      .query('friendRecs')
+      .withIndex('by_userId', (q) => q.eq('userId', userId))
+      .unique();
+
+    if (!rec) return null;
+
+    const now = Date.now();
+    const INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
+
+    const isFresh = rec.updatedAt ? now - rec.updatedAt < INTERVAL : false;
+
+    return {
+      recs: rec.recs,
+      isFresh,
+      updatedAt: rec.updatedAt,
+    };
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -80,6 +80,7 @@ export default defineSchema({
         score: v.number(),
       })
     ),
+    updatedAt: v.number(),
   }).index('by_userId', ['userId']),
 
   friends: defineTable({


### PR DESCRIPTION
## Summary

Adds time-based freshness tracking to friend recommendations by introducing an updatedAt timestamp and backend logic to determine whether recommendations are stale.
---

## Why is this change necessary?

Previously, friend recommendations were stored without any notion of time, which meant stale or outdated recommendations could be served indefinitely.

This change introduces a time-based mechanism to track when recommendations were last updated and allows the backend to determine whether they are still fresh. This lays the foundation for future improvements such as automatic recomputation or refresh triggers.

Closes #26 

---

## Changes

- Added `updatedAt` field to `friendRecs` schema
- Updated `upsert` mutation to store timestamp using `Date.now()`
- Implemented `getFriendRecs` query:
  - Retrieves recommendations by userId
  - Computes freshness based on a 24-hour interval
  - Returns recs along with freshness metadata
- Ensured compatibility with existing records by handling missing timestamps
---

## Testing

Step-by-step instructions for reviewers to verify the changes.

1. Run backend locally: pnpm convex:dev

2. Trigger friend recommendation generation (via Python script or mutation)

3. Call `getFriendRecs` query:
   - Verify recommendations are returned
   - Verify `isFresh` is true immediately after update

## Notes / Acknowledgments (optional)

Example:
Let INTERVAL = 24 hours = 86,400,000 ms

Case 1 (Fresh):
- now = 1,000,000
- updatedAt = 950,000
- difference = 50,000 < INTERVAL → isFresh = true

Case 2 (Stale):
- now = 1,000,000
- updatedAt = 0
- difference = 1,000,000 > INTERVAL → isFresh = false

Future Work:
- Trigger recomputation when recommendations become stale
- Introduce dynamic freshness intervals based on user activity
- Support event-driven updates (e.g., friend graph or location changes)
- Implement background refresh to avoid user-facing latency
- Replace binary freshness with a continuous freshness score