### PR TITLE
refactor(backend): Fixed mypy check issues for event recs

### DIFF
--- a/packages/data-ml/event-rec/updateUserPreference.py
+++ b/packages/data-ml/event-rec/updateUserPreference.py
@@ -6,6 +6,10 @@ from dotenv import load_dotenv
 
 load_dotenv()
 CONVEX_CLOUD_URL = os.getenv("CONVEX_CLOUD_URL")
+
+if CONVEX_CLOUD_URL is None:
+    raise EnvironmentError("Required environment variable CONVEX_CLOUD_URL is not set")
+
 client = ConvexClient(CONVEX_CLOUD_URL)
 
 # Controls how quickly scores saturate toward 1
@@ -88,7 +92,7 @@ def build_user_tag_weights(user_tag_counts: dict[str, np.ndarray], alpha: float 
     return user_preference_weights
 
 
-def main(users: list[str]):
+def main(users: list[str]) -> None:
     user_event_multihot = get_user_event_multihot(USERS)
 
     user_preference_weights = build_user_tag_weights(user_event_multihot)


### PR DESCRIPTION

## Summary

Fixed issues with even rec system conflicting with new mypy checks.

---

## Why is this change necessary?

1. CONVEX_CLOUD_URL could be None, so a check is required.
2. main() was missing a return type annotation.

---

## Changes

Main changes introduced in this PR:

- Moved ```updateUserPreference.py``` into ```packages/data-ml/event-rec/```
- Added ```-> None``` return type annotation to ```main()```
- Added ```None``` guard for ```CONVEX_CLOUD_URL```

---

## Testing

Step-by-step instructions for reviewers to verify the changes.

- Refer back to PR #71 