### PR TITLE
fix(web): fix turbo json env vars

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,17 @@
 {
-  "$schema": "https://v2-9-5.turborepo.dev/schema.json",
+  "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
   "globalEnv": ["ANDROID_HOME", "ANDROID_SDK_ROOT"],
   "tasks": {
     "build": {
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "env": [
+        "CLERK_SECRET_KEY",
+        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "NEXT_PUBLIC_CONVEX_URL",
+        "NEXT_PUBLIC_MAPBOX_TOKEN"
+      ]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary

This PR updates the Turbo build configuration used by Vercel. It removes unstable page-scoped styles from the map route and declares the web app's required build-time environment variables in `turbo.json`.

---

## Why is this change necessary?

Vercel was warning that required environment variables were present in the project settings but missing from `turbo.json`, which can lead to incorrect build caching and harder-to-debug deployment behavior.

---

## Changes

Main changes introduced in this PR:

- Updated `turbo.json` to use the current Turbo schema URL.
- Added the web build env vars to `tasks.build.env`:
  - `CLERK_SECRET_KEY`
  - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
  - `NEXT_PUBLIC_CONVEX_URL`
  - `NEXT_PUBLIC_MAPBOX_TOKEN`

---

## Testing

Step-by-step instructions for reviewers to verify the changes.

1. Run `pnpm.cmd --filter @fomo/web typecheck`
2. Run `pnpm.cmd --filter @fomo/web lint`
3. Confirm Vercel no longer warns that the web build environment variables are missing from `turbo.json`

## Screenshots / UI Changes

No intentional visual UI changes beyond the map page rendering correctly after hydration.


## References
- Turbo schema docs: https://turbo.build/schema.json
