### PR TITLE
Cron Job for Event and Friend Recommendations

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -16,7 +16,6 @@ import type * as data_ml_friends from "../data_ml/friends.js";
 import type * as data_ml_universal from "../data_ml/universal.js";
 import type * as data_ml_users from "../data_ml/users.js";
 import type * as data_ml_usersToEvents from "../data_ml/usersToEvents.js";
-
 import type * as eventSeedsStatic from "../eventSeedsStatic.js";
 import type * as eventsIngest from "../eventsIngest.js";
 import type * as likes from "../likes.js";
@@ -38,7 +37,6 @@ declare const fullApi: ApiFromModules<{
   "data_ml/universal": typeof data_ml_universal;
   "data_ml/users": typeof data_ml_users;
   "data_ml/usersToEvents": typeof data_ml_usersToEvents;
-
   eventSeedsStatic: typeof eventSeedsStatic;
   eventsIngest: typeof eventsIngest;
   likes: typeof likes;

--- a/packages/data_ml/event_rec/recommendEvent.py
+++ b/packages/data_ml/event_rec/recommendEvent.py
@@ -25,12 +25,10 @@ def get_client() -> ConvexClient:
         raise RuntimeError("ConvexClient not initialized")
     return client
 
-def get_pretty_time() -> str:
-    now = datetime.now()
-    return f"[{now.strftime("%H:%M:%S %m/%d/%y")}]"
-
 def log(message: str) -> None:
-    print(f"{get_pretty_time()} {message}")
+    now = datetime.now()
+    pretty_time = f"[{now.strftime("%H:%M:%S %m/%d/%y")}]"
+    print(f"{pretty_time} {message}")
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/packages/data_ml/event_rec/recommendEvent.py
+++ b/packages/data_ml/event_rec/recommendEvent.py
@@ -6,6 +6,8 @@ from numpy.typing import NDArray
 from convex import ConvexClient
 from dotenv import load_dotenv
 from typing import Optional, Any
+from datetime import datetime
+from pathlib import Path
 
 
 from models.twoTowerModel import UserTower, EventTower
@@ -23,6 +25,12 @@ def get_client() -> ConvexClient:
         raise RuntimeError("ConvexClient not initialized")
     return client
 
+def get_pretty_time() -> str:
+    now = datetime.now()
+    return f"[{now.strftime("%H:%M:%S %m/%d/%y")}]"
+
+def log(message: str) -> None:
+    print(f"{get_pretty_time()} {message}")
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -170,7 +178,10 @@ USERS = ["ALL"]
 UPDATE_DB = False
 
 if __name__ == "__main__":
-    main(USERS, UPDATE_DB, 'models/curr_model.pt')
+    log("Updating event recommendations...")
+    model_dir = os.path.join(Path(__file__).parent, "models", "curr_model.pt")
+    main(USERS, UPDATE_DB, model_dir)
+    log("Event recommendations updated.")
 
 """ 
 TODO: 

--- a/packages/data_ml/friendRec/friendRecs.py
+++ b/packages/data_ml/friendRec/friendRecs.py
@@ -18,13 +18,11 @@ def get_client() -> ConvexClient:
         raise RuntimeError("ConvexClient not initialized")
     return client
 
-def get_pretty_time() -> str:
-    now = datetime.now()
-    return f"[{now.strftime("%H:%M:%S %m/%d/%y")}]"
-
 def log(message: str) -> None:
-    print(f"{get_pretty_time()} {message}")
-
+    now = datetime.now()
+    pretty_time = f"[{now.strftime("%H:%M:%S %m/%d/%y")}]"
+    print(f"{pretty_time} {message}")
+    
 # Checks if a userid exists in the "users" table.
 def user_exists(user_id: str) -> bool:
     return get_client().query("data_ml/users:userExists", {"userId": user_id}) is not None

--- a/packages/data_ml/friendRec/friendRecs.py
+++ b/packages/data_ml/friendRec/friendRecs.py
@@ -4,6 +4,7 @@ from typing import Optional
 from convex import ConvexClient
 from dotenv import load_dotenv
 from sklearn.metrics.pairwise import cosine_similarity
+from datetime import datetime
 
 load_dotenv()
 CONVEX_CLOUD_URL = os.getenv("CONVEX_CLOUD_URL")
@@ -17,7 +18,12 @@ def get_client() -> ConvexClient:
         raise RuntimeError("ConvexClient not initialized")
     return client
 
+def get_pretty_time() -> str:
+    now = datetime.now()
+    return f"[{now.strftime("%H:%M:%S %m/%d/%y")}]"
 
+def log(message: str) -> None:
+    print(f"{get_pretty_time()} {message}")
 
 # Checks if a userid exists in the "users" table.
 def user_exists(user_id: str) -> bool:
@@ -249,5 +255,7 @@ REC_AMT  = 5         # friendRecs schema only currently supports 5.
 SEED     = False      # Dictates if fake data needs to be populated into Convex.
 
 if __name__ == "__main__":
+    log("Updating friend recommendations...")
     main_all_users(REC_AMT, SEED)
+    log("Friend recommendations updated.")
 

--- a/packages/data_ml/recs_cron_script
+++ b/packages/data_ml/recs_cron_script
@@ -1,0 +1,25 @@
+# Edit this file to introduce tasks to be run by cron.
+# 
+# Each task to run has to be defined through a single line
+# indicating with different fields when the task will be run
+# and what command to run for the task
+# 
+# To define the time you can provide concrete values for
+# minute (m), hour (h), day of month (dom), month (mon),
+# and day of week (dow) or use '*' in these fields (for 'any').
+# 
+# Notice that tasks will be started based on the cron's system
+# daemon's notion of time and timezones.
+# 
+# Output of the crontab jobs (including errors) is sent through
+# email to the user the crontab file belongs to (unless redirected).
+# 
+# For example, you can run a backup of all your user accounts
+# at 5 a.m every week with:
+# 0 5 * * 1 tar -zcf /var/backups/home.tgz /home/
+# 
+# For more information see the manual pages of crontab(5) and cron(8)
+# 
+# m h  dom mon dow   command
+0 * * * * cd /srv/2026-S-GROUP2-FOMO/packages/data-ml/ && /root/.local/bin/uv run friendRec/friendRecs.py >> /tmp/recs.log 2>&1
+0 * * * * cd /srv/2026-S-GROUP2-FOMO/packages/data-ml/ && /root/.local/bin/uv run event_rec/recommendEvent.py >> /tmp/recs.log 2>&1

--- a/packages/data_ml/tests/test_friendRecs.py
+++ b/packages/data_ml/tests/test_friendRecs.py
@@ -8,6 +8,7 @@ from typing import Generator
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "friendRec"))
 from friendRecs import (
+    log,
     user_exists,
     join_user_events,
     raw_matrix_events,
@@ -103,6 +104,17 @@ def sample_score_df() -> pd.DataFrame:
 # ------------------------------
 #  user_exists()
 # ------------------------------
+
+class TestLog:
+    def test_log_prints_timestamped_message(self) -> None:
+        with patch("friendRecs.datetime") as mock_datetime, patch("friendRecs.print") as mock_print:
+            mock_now = MagicMock()
+            mock_now.strftime.return_value = "12:34:56 01/02/26"
+            mock_datetime.now.return_value = mock_now
+
+            log("hello world")
+
+        mock_print.assert_called_once_with("[12:34:56 01/02/26] hello world")
 
 # Should return true, since this fake data DOES exist in "users"
 def test_user_exists_returns_true(mock_client: MagicMock) -> None:

--- a/packages/data_ml/tests/test_recommendEvent.py
+++ b/packages/data_ml/tests/test_recommendEvent.py
@@ -13,6 +13,7 @@ from recommendEvent import (
     get_tag_info,
     get_user_features,
     get_event_features,
+    log,
     main,
     MAX_TAGS
 )
@@ -120,6 +121,18 @@ class TestGetTagInfo:
 
         assert num_tags == 0
         assert len(tag_id_to_idx) == 0
+
+
+class TestLog:
+    def test_log_prints_timestamped_message(self) -> None:
+        with patch("recommendEvent.datetime") as mock_datetime, patch("recommendEvent.print") as mock_print:
+            mock_now = MagicMock()
+            mock_now.strftime.return_value = "12:34:56 01/02/26"
+            mock_datetime.now.return_value = mock_now
+
+            log("hello world")
+
+        mock_print.assert_called_once_with("[12:34:56 01/02/26] hello world")
 
 
 class TestGetUserFeatures:


### PR DESCRIPTION
<!--
Before submitting this PR:
- Add appropriate labels (feature, bug, refactor, chore, docs, etc.)
- Link any related issues
- Ensure tests/build pass
-->

## Summary

Introduces an hourly cron job hosted on a new Debian-based server that refreshes friend and event recommendation tables. Basic logging is included, so cron task output is observable.

---

## Why is this change necessary?

Recommendation data was previously manually triggered. There was no automated pipeline to keep friend and event suggestions fresh. A dedicated server and scheduled job ensure recommendations stay up to date without manual intervention.

Closes #93 

---

## Changes

Main changes introduced in this PR:

- Provisioned a Debian server configured for the project environment
- Added an hourly cron job script that updates the friend recommendation table and event recommendation table
- Integrated basic logging for cron task execution

## Testing

1. Run `cd packages/data_ml`.
2. Run `uv run python friendRec/friendRecs.py` to ensure there are no errors.
3. Run `uv run python event_rec/recommendEvent.py` to ensure there are no errors.