### PR TITLE
Add Friend on Mobile

### DIFF
--- a/apps/mobile/src/app/(tabs)/(map)/event/profile/[username].tsx
+++ b/apps/mobile/src/app/(tabs)/(map)/event/profile/[username].tsx
@@ -1,14 +1,17 @@
 import { ProfilePage, ProfileStateScreen } from '@/features/profile/profile-page';
+import { useUser } from '@clerk/expo';
 import { api } from '@fomo/backend/convex/_generated/api';
 import { useQuery } from 'convex/react';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 
 export default function EventProfileScreen() {
   const router = useRouter();
+  const { isSignedIn } = useUser();
   const { username: rawUsername } = useLocalSearchParams<{ username?: string | string[] }>();
   const username = Array.isArray(rawUsername) ? rawUsername[0] : rawUsername;
   const screenTitle = username ?? 'Profile';
 
+  const viewerProfile = useQuery(api.users.getCurrentProfileMinimal, isSignedIn ? {} : 'skip');
   const profile = useQuery(api.users.getProfileByUsername, username ? { username } : 'skip');
   const feedPosts = useQuery(
     api.users.getProfileFeed,
@@ -63,6 +66,7 @@ export default function EventProfileScreen() {
         activityLabel="Recent Events"
         topPaddingClassName="pt-5"
         mediaFeedPathname="/(tabs)/(map)/event/profile/media-feed"
+        viewerUserId={viewerProfile?.id}
       />
     </>
   );

--- a/apps/mobile/src/app/(tabs)/(map)/event/profile/[username].tsx
+++ b/apps/mobile/src/app/(tabs)/(map)/event/profile/[username].tsx
@@ -1,17 +1,16 @@
 import { ProfilePage, ProfileStateScreen } from '@/features/profile/profile-page';
-import { useUser } from '@clerk/expo';
 import { api } from '@fomo/backend/convex/_generated/api';
-import { useQuery } from 'convex/react';
+import { useConvexAuth, useQuery } from 'convex/react';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 
 export default function EventProfileScreen() {
   const router = useRouter();
-  const { isSignedIn } = useUser();
+  const { isAuthenticated } = useConvexAuth();
   const { username: rawUsername } = useLocalSearchParams<{ username?: string | string[] }>();
   const username = Array.isArray(rawUsername) ? rawUsername[0] : rawUsername;
   const screenTitle = username ?? 'Profile';
 
-  const viewerProfile = useQuery(api.users.getCurrentProfileMinimal, isSignedIn ? {} : 'skip');
+  const viewerProfile = useQuery(api.users.getCurrentProfileMinimal, isAuthenticated ? {} : 'skip');
   const profile = useQuery(api.users.getProfileByUsername, username ? { username } : 'skip');
   const feedPosts = useQuery(
     api.users.getProfileFeed,

--- a/apps/mobile/src/app/(tabs)/profile/[username].tsx
+++ b/apps/mobile/src/app/(tabs)/profile/[username].tsx
@@ -1,14 +1,17 @@
 import { ProfilePage, ProfileStateScreen } from '@/features/profile/profile-page';
+import { useUser } from '@clerk/expo';
 import { api } from '@fomo/backend/convex/_generated/api';
 import { useQuery } from 'convex/react';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 
 export default function VisitProfileScreen() {
   const router = useRouter();
+  const { isSignedIn } = useUser();
   const { username: rawUsername } = useLocalSearchParams<{ username?: string | string[] }>();
   const username = Array.isArray(rawUsername) ? rawUsername[0] : rawUsername;
   const screenTitle = username ?? 'Profile';
 
+  const viewerProfile = useQuery(api.users.getCurrentProfileMinimal, isSignedIn ? {} : 'skip');
   const profile = useQuery(api.users.getProfileByUsername, username ? { username } : 'skip');
   const feedPosts = useQuery(
     api.users.getProfileFeed,
@@ -49,6 +52,7 @@ export default function VisitProfileScreen() {
         }}
         activityLabel="Recent Events"
         topPaddingClassName="pt-5"
+        viewerUserId={viewerProfile?.id}
       />
     </>
   );

--- a/apps/mobile/src/app/(tabs)/profile/[username].tsx
+++ b/apps/mobile/src/app/(tabs)/profile/[username].tsx
@@ -1,17 +1,16 @@
 import { ProfilePage, ProfileStateScreen } from '@/features/profile/profile-page';
-import { useUser } from '@clerk/expo';
 import { api } from '@fomo/backend/convex/_generated/api';
-import { useQuery } from 'convex/react';
+import { useConvexAuth, useQuery } from 'convex/react';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 
 export default function VisitProfileScreen() {
   const router = useRouter();
-  const { isSignedIn } = useUser();
+  const { isAuthenticated } = useConvexAuth();
   const { username: rawUsername } = useLocalSearchParams<{ username?: string | string[] }>();
   const username = Array.isArray(rawUsername) ? rawUsername[0] : rawUsername;
   const screenTitle = username ?? 'Profile';
 
-  const viewerProfile = useQuery(api.users.getCurrentProfileMinimal, isSignedIn ? {} : 'skip');
+  const viewerProfile = useQuery(api.users.getCurrentProfileMinimal, isAuthenticated ? {} : 'skip');
   const profile = useQuery(api.users.getProfileByUsername, username ? { username } : 'skip');
   const feedPosts = useQuery(
     api.users.getProfileFeed,

--- a/apps/mobile/src/app/(tabs)/profile/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/_layout.tsx
@@ -12,6 +12,7 @@ export default function ProfileLayout() {
       <Stack.Screen name="index" options={{ headerShown: false }} />
       <Stack.Screen name="[username]" /> {/* NOTE :: header handled inside the [username] screen */}
       <Stack.Screen name="friends" options={{ title: 'Friends' }} />
+      <Stack.Screen name="friend-requests" options={{ title: 'Friend Requests' }} />
       <Stack.Screen name="settings" options={{ title: 'Settings' }} />
       <Stack.Screen name="media-feed" options={{ title: 'Media' }} />
     </Stack>

--- a/apps/mobile/src/app/(tabs)/profile/friend-requests.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/friend-requests.tsx
@@ -1,0 +1,262 @@
+import { Screen } from '@/components/ui/screen';
+import { FriendCell } from '@/features/profile/components/friend-cell';
+import { useUser } from '@clerk/expo';
+import { MaterialIcons } from '@expo/vector-icons';
+import { api } from '@fomo/backend/convex/_generated/api';
+import type { Id } from '@fomo/backend/convex/_generated/dataModel';
+import { useMutation, useQuery } from 'convex/react';
+import { useRouter } from 'expo-router';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
+
+export default function FriendRequestsScreen() {
+  const router = useRouter();
+  const { isSignedIn } = useUser();
+  const requests = useQuery(api.friends.getFriendRequests, isSignedIn ? {} : 'skip');
+  const acceptFriendRequest = useMutation(api.friends.acceptFriendRequest);
+  const declineFriendRequest = useMutation(api.friends.declineFriendRequest);
+  const cancelFriendRequest = useMutation(api.friends.cancelFriendRequest);
+  const [pendingUserId, setPendingUserId] = useState<string | null>(null);
+
+  async function handleRespond(requesterId: Id<'users'>, action: 'accept' | 'decline') {
+    if (pendingUserId === requesterId) {
+      return;
+    }
+
+    setPendingUserId(requesterId);
+    try {
+      if (action === 'accept') {
+        await acceptFriendRequest({ requesterId });
+      } else {
+        await declineFriendRequest({ requesterId });
+      }
+    } catch (error) {
+      console.error(`Failed to ${action} friend request`, error);
+      Alert.alert(
+        'Unable to update request',
+        error instanceof Error ? error.message : 'Please try again.'
+      );
+    } finally {
+      setPendingUserId(null);
+    }
+  }
+
+  async function handleCancel(recipientId: Id<'users'>) {
+    if (pendingUserId === recipientId) {
+      return;
+    }
+
+    setPendingUserId(recipientId);
+    try {
+      await cancelFriendRequest({ recipientId });
+    } catch (error) {
+      console.error('Failed to cancel friend request', error);
+      Alert.alert(
+        'Unable to remove request',
+        error instanceof Error ? error.message : 'Please try again.'
+      );
+    } finally {
+      setPendingUserId(null);
+    }
+  }
+
+  return (
+    <Screen className="flex-1">
+      <ScrollView className="flex-1 bg-background pt-5" contentContainerClassName="px-4 pb-8">
+        <Text className="mb-4 text-2xl font-bold text-foreground">Friend Requests</Text>
+        {requests === undefined ? (
+          <Text className="text-muted-foreground">Loading requests...</Text>
+        ) : requests.received.length === 0 && requests.sent.length === 0 ? (
+          <Text className="text-muted-foreground">No pending friend requests.</Text>
+        ) : (
+          <View className="gap-4">
+            <RequestSection title="Received">
+              {requests.received.length === 0 ? (
+                <Text className="text-sm text-muted-foreground">No received requests.</Text>
+              ) : (
+                requests.received.map((request) => {
+                  const isPending = pendingUserId === String(request.id);
+
+                  return (
+                    <ReceivedRequestRow
+                      key={`received-${request.id}`}
+                      username={request.username}
+                      displayName={request.displayName}
+                      avatarUrl={request.avatarUrl}
+                      isPending={isPending}
+                      onPress={() =>
+                        router.push({
+                          pathname: '/profile/[username]',
+                          params: { id: String(request.id), username: request.username },
+                        })
+                      }
+                      onAccept={() => {
+                        void handleRespond(request.id, 'accept');
+                      }}
+                      onDecline={() => {
+                        void handleRespond(request.id, 'decline');
+                      }}
+                    />
+                  );
+                })
+              )}
+            </RequestSection>
+
+            <RequestSection title="Sent">
+              {requests.sent.length === 0 ? (
+                <Text className="text-sm text-muted-foreground">No sent requests.</Text>
+              ) : (
+                requests.sent.map((request) => {
+                  const isPending = pendingUserId === String(request.id);
+
+                  return (
+                    <SentRequestRow
+                      key={`sent-${request.id}`}
+                      username={request.username}
+                      displayName={request.displayName}
+                      avatarUrl={request.avatarUrl}
+                      isPending={isPending}
+                      onPress={() =>
+                        router.push({
+                          pathname: '/profile/[username]',
+                          params: { id: String(request.id), username: request.username },
+                        })
+                      }
+                      onRemove={() => {
+                        void handleCancel(request.id);
+                      }}
+                    />
+                  );
+                })
+              )}
+            </RequestSection>
+          </View>
+        )}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function RequestSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <View className="gap-3">
+      <Text className="text-lg font-semibold text-foreground">{title}</Text>
+      <View className="border-y border-border px-4">{children}</View>
+    </View>
+  );
+}
+
+function SentRequestRow({
+  username,
+  displayName,
+  avatarUrl,
+  isPending,
+  onPress,
+  onRemove,
+}: {
+  username: string;
+  displayName?: string;
+  avatarUrl?: string;
+  isPending: boolean;
+  onPress: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <FriendCell
+      username={username}
+      displayName={displayName}
+      avatarUrl={avatarUrl}
+      onPress={onPress}
+      className="py-3"
+      rightAccessory={
+        <ProfileRequestIconButton
+          accessibilityLabel="Remove sent friend request"
+          iconName="close"
+          tone="decline"
+          onPress={onRemove}
+          disabled={isPending}
+        />
+      }
+    />
+  );
+}
+
+function ReceivedRequestRow({
+  username,
+  displayName,
+  avatarUrl,
+  isPending,
+  onPress,
+  onAccept,
+  onDecline,
+}: {
+  username: string;
+  displayName?: string;
+  avatarUrl?: string;
+  isPending: boolean;
+  onPress: () => void;
+  onAccept: () => void;
+  onDecline: () => void;
+}) {
+  return (
+    <FriendCell
+      username={username}
+      displayName={displayName}
+      avatarUrl={avatarUrl}
+      onPress={onPress}
+      className="py-3"
+      rightAccessory={
+        <View className="flex-row items-center gap-2">
+          <ProfileRequestIconButton
+            accessibilityLabel="Accept friend request"
+            iconName="check"
+            tone="accept"
+            onPress={onAccept}
+            disabled={isPending}
+          />
+          <ProfileRequestIconButton
+            accessibilityLabel="Decline friend request"
+            iconName="close"
+            tone="decline"
+            onPress={onDecline}
+            disabled={isPending}
+          />
+        </View>
+      }
+    />
+  );
+}
+
+function ProfileRequestIconButton({
+  accessibilityLabel,
+  disabled,
+  iconName,
+  tone,
+  onPress,
+}: {
+  accessibilityLabel: string;
+  disabled: boolean;
+  iconName: 'check' | 'close';
+  tone: 'accept' | 'decline';
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      className={`size-10 items-center justify-center rounded-full ${
+        tone === 'accept' ? 'bg-green-500/15' : 'bg-destructive/10'
+      }`}
+      disabled={disabled}
+      hitSlop={8}
+      style={({ pressed }) => [
+        pressed && { opacity: 0.9, transform: [{ scale: 0.96 }] },
+        disabled && { opacity: 0.5 },
+      ]}
+      onPress={onPress}
+    >
+      <MaterialIcons name={iconName} size={20} color={tone === 'accept' ? '#16a34a' : '#dc2626'} />
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/app/(tabs)/profile/friend-requests.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/friend-requests.tsx
@@ -1,10 +1,9 @@
 import { Screen } from '@/components/ui/screen';
 import { FriendCell } from '@/features/profile/components/friend-cell';
-import { useUser } from '@clerk/expo';
 import { MaterialIcons } from '@expo/vector-icons';
 import { api } from '@fomo/backend/convex/_generated/api';
 import type { Id } from '@fomo/backend/convex/_generated/dataModel';
-import { useMutation, useQuery } from 'convex/react';
+import { useConvexAuth, useMutation, useQuery } from 'convex/react';
 import { useRouter } from 'expo-router';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
@@ -12,8 +11,8 @@ import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
 
 export default function FriendRequestsScreen() {
   const router = useRouter();
-  const { isSignedIn } = useUser();
-  const requests = useQuery(api.friends.getFriendRequests, isSignedIn ? {} : 'skip');
+  const { isAuthenticated } = useConvexAuth();
+  const requests = useQuery(api.friends.getFriendRequests, isAuthenticated ? {} : 'skip');
   const acceptFriendRequest = useMutation(api.friends.acceptFriendRequest);
   const declineFriendRequest = useMutation(api.friends.declineFriendRequest);
   const cancelFriendRequest = useMutation(api.friends.cancelFriendRequest);

--- a/apps/mobile/src/app/(tabs)/profile/friends.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/friends.tsx
@@ -1,9 +1,8 @@
 import { Screen } from '@/components/ui/screen';
 import { FriendCell } from '@/features/profile/components/friend-cell';
 import { useAppTheme } from '@/lib/use-app-theme';
-import { useUser } from '@clerk/expo';
 import { api } from '@fomo/backend/convex/_generated/api';
-import { useQuery } from 'convex/react';
+import { useConvexAuth, useQuery } from 'convex/react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useMemo, useState } from 'react';
 import { ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native';
@@ -13,14 +12,17 @@ export function FriendsScreenContent() {
   const router = useRouter();
   const params = useLocalSearchParams<{ source?: string | string[] }>();
   const theme = useAppTheme();
-  const { isSignedIn } = useUser();
+  const { isAuthenticated } = useConvexAuth();
   const [searchText, setSearchText] = useState('');
   const [isRecommendedCollapsed, setIsRecommendedCollapsed] = useState(false);
   const source = Array.isArray(params.source) ? params.source[0] : params.source;
   const showRecommendedFriends = source !== 'profile-visit';
 
-  const friendRecResult = useQuery(api.data_ml.friends.getFriendRecs, isSignedIn ? {} : 'skip');
-  const friendsResult = useQuery(api.data_ml.friends.getFriends, isSignedIn ? {} : 'skip');
+  const friendRecResult = useQuery(
+    api.data_ml.friends.getFriendRecs,
+    isAuthenticated ? {} : 'skip'
+  );
+  const friendsResult = useQuery(api.data_ml.friends.getFriends, isAuthenticated ? {} : 'skip');
 
   const recommendedFriends = friendRecResult?.recs ?? [];
 

--- a/apps/mobile/src/app/(tabs)/profile/index.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/index.tsx
@@ -1,11 +1,14 @@
+import { ButtonText } from '@/components/ui/button';
 import { Screen } from '@/components/ui/screen';
 import { Authenticated, GuestOnly } from '@/features/auth/components/auth-gate';
 import { ProfilePage } from '@/features/profile/profile-page';
+import { useAppTheme } from '@/lib/use-app-theme';
 import { useUser } from '@clerk/expo';
+import { MaterialIcons } from '@expo/vector-icons';
 import { api } from '@fomo/backend/convex/_generated/api';
 import { useQuery } from 'convex/react';
 import { useRouter } from 'expo-router';
-import { ScrollView } from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
 
 // imports for authentication and guest mode
 import { GuestMode } from '@/features/profile/components/guest-mode';
@@ -16,6 +19,7 @@ export default function ProfileScreen() {
   const { isSignedIn } = useUser();
   const profile = useQuery(api.users.getCurrentProfile, isSignedIn ? {} : 'skip');
   const friends = useQuery(api.data_ml.friends.getFriends, isSignedIn ? {} : 'skip');
+  const friendRequests = useQuery(api.friends.getFriendRequests, isSignedIn ? {} : 'skip');
   const feedPosts = useQuery(
     api.users.getProfileFeed,
     profile ? { userId: profile.user._id } : 'skip'
@@ -40,11 +44,44 @@ export default function ProfileScreen() {
             onPressSettings={() => router.push('/profile/settings')}
             topPaddingClassName="pt-20"
             bioFallback="No bio yet."
+            viewerUserId={profile.user._id}
+            profileAction={
+              <ProfileRequestsButton
+                count={friendRequests?.received.length ?? 0}
+                onPress={() => router.push('/profile/friend-requests')}
+              />
+            }
           />
         ) : (
           <ScrollView className="flex-1 bg-background" />
         )}
       </Authenticated>
     </Screen>
+  );
+}
+
+function ProfileRequestsButton({ count, onPress }: { count: number; onPress: () => void }) {
+  const theme = useAppTheme();
+
+  return (
+    <View>
+      <Pressable
+        accessibilityLabel="Friend requests"
+        accessibilityRole="button"
+        className="size-12 items-center justify-center rounded-full bg-card shadow-sm"
+        hitSlop={10}
+        style={({ pressed }) => [pressed && { opacity: 0.9, transform: [{ scale: 0.96 }] }]}
+        onPress={onPress}
+      >
+        <MaterialIcons name="person-add-alt-1" size={20} color={theme.tint} />
+      </Pressable>
+      {count > 0 ? (
+        <View className="absolute -right-1 -top-1 min-h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1">
+          <ButtonText className="text-xs text-primary-foreground">
+            {count > 9 ? '9+' : count}
+          </ButtonText>
+        </View>
+      ) : null}
+    </View>
   );
 }

--- a/apps/mobile/src/app/(tabs)/profile/index.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/index.tsx
@@ -3,10 +3,9 @@ import { Screen } from '@/components/ui/screen';
 import { Authenticated, GuestOnly } from '@/features/auth/components/auth-gate';
 import { ProfilePage } from '@/features/profile/profile-page';
 import { useAppTheme } from '@/lib/use-app-theme';
-import { useUser } from '@clerk/expo';
 import { MaterialIcons } from '@expo/vector-icons';
 import { api } from '@fomo/backend/convex/_generated/api';
-import { useQuery } from 'convex/react';
+import { useConvexAuth, useQuery } from 'convex/react';
 import { useRouter } from 'expo-router';
 import { Pressable, ScrollView, View } from 'react-native';
 
@@ -16,10 +15,10 @@ import { GuestMode } from '@/features/profile/components/guest-mode';
 export default function ProfileScreen() {
   const router = useRouter();
 
-  const { isSignedIn } = useUser();
-  const profile = useQuery(api.users.getCurrentProfile, isSignedIn ? {} : 'skip');
-  const friends = useQuery(api.data_ml.friends.getFriends, isSignedIn ? {} : 'skip');
-  const friendRequests = useQuery(api.friends.getFriendRequests, isSignedIn ? {} : 'skip');
+  const { isAuthenticated } = useConvexAuth();
+  const profile = useQuery(api.users.getCurrentProfile, isAuthenticated ? {} : 'skip');
+  const friends = useQuery(api.data_ml.friends.getFriends, isAuthenticated ? {} : 'skip');
+  const friendRequests = useQuery(api.friends.getFriendRequests, isAuthenticated ? {} : 'skip');
   const feedPosts = useQuery(
     api.users.getProfileFeed,
     profile ? { userId: profile.user._id } : 'skip'

--- a/apps/mobile/src/features/profile/components/friend-cell.tsx
+++ b/apps/mobile/src/features/profile/components/friend-cell.tsx
@@ -1,4 +1,6 @@
 import { Avatar } from '@/features/posts/components/avatar';
+import { cn } from '@/lib/utils';
+import type { ReactNode } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 
 type FriendCellProps = {
@@ -6,14 +8,29 @@ type FriendCellProps = {
   displayName?: string;
   avatarUrl?: string;
   onPress?: () => void;
+  rightAccessory?: ReactNode;
+  className?: string;
+  showBorder?: boolean;
 };
 
-export function FriendCell({ username, displayName, avatarUrl, onPress }: FriendCellProps) {
+export function FriendCell({
+  username,
+  displayName,
+  avatarUrl,
+  onPress,
+  rightAccessory,
+  className,
+  showBorder = true,
+}: FriendCellProps) {
   return (
     <TouchableOpacity
       onPress={onPress}
       activeOpacity={onPress ? 0.7 : 1}
-      className="flex-row items-center border-b border-border py-3"
+      className={cn(
+        'flex-row items-center py-3',
+        showBorder && 'border-b border-border',
+        className
+      )}
       accessibilityRole={onPress ? 'button' : 'none'}
       accessibilityLabel={`${username}${displayName ? `, ${displayName}` : ''}`}
     >
@@ -29,6 +46,8 @@ export function FriendCell({ username, displayName, avatarUrl, onPress }: Friend
         <Text className="text-base font-semibold text-foreground">{username}</Text>
         {displayName ? <Text className="text-sm text-muted-foreground">{displayName}</Text> : null}
       </View>
+
+      {rightAccessory ? <View className="ml-3">{rightAccessory}</View> : null}
     </TouchableOpacity>
   );
 }

--- a/apps/mobile/src/features/profile/profile-page.tsx
+++ b/apps/mobile/src/features/profile/profile-page.tsx
@@ -8,11 +8,10 @@ import StatLabel from '@/features/profile/components/stat-label';
 import { useGuest } from '@/integrations/session/guest';
 import { useAppTheme } from '@/lib/use-app-theme';
 import { cn } from '@/lib/utils';
-import { useUser } from '@clerk/expo';
 import { MaterialIcons } from '@expo/vector-icons';
 import { api } from '@fomo/backend/convex/_generated/api';
 import type { Id } from '@fomo/backend/convex/_generated/dataModel';
-import { useMutation, useQuery } from 'convex/react';
+import { useConvexAuth, useMutation, useQuery } from 'convex/react';
 import { FunctionReturnType } from 'convex/server';
 import { useRouter } from 'expo-router';
 import type { ComponentProps, ReactNode } from 'react';
@@ -112,7 +111,7 @@ export function ProfilePage({
   const userId = profile.user._id;
   const theme = useAppTheme();
   const router = useRouter();
-  const { isSignedIn } = useUser();
+  const { isAuthenticated } = useConvexAuth();
   const { isGuestMode } = useGuest();
   const togglePostLike = useMutation(api.likes.togglePostLike);
   const sendFriendRequest = useMutation(api.friends.sendFriendRequest);
@@ -124,7 +123,7 @@ export function ProfilePage({
   const [isUpdatingFriendship, setIsUpdatingFriendship] = useState(false);
   const friendship = useQuery(
     api.friends.getFriendshipStatusForUser,
-    isSignedIn && viewerUserId && viewerUserId !== userId ? { otherUserId: userId } : 'skip'
+    isAuthenticated && viewerUserId && viewerUserId !== userId ? { otherUserId: userId } : 'skip'
   );
 
   function handlePressGridItem(item: GridMediaItem) {

--- a/apps/mobile/src/features/profile/profile-page.tsx
+++ b/apps/mobile/src/features/profile/profile-page.tsx
@@ -7,14 +7,17 @@ import { MediaGrid, type GridMediaItem } from '@/features/profile/components/med
 import StatLabel from '@/features/profile/components/stat-label';
 import { useGuest } from '@/integrations/session/guest';
 import { useAppTheme } from '@/lib/use-app-theme';
+import { cn } from '@/lib/utils';
+import { useUser } from '@clerk/expo';
 import { MaterialIcons } from '@expo/vector-icons';
 import { api } from '@fomo/backend/convex/_generated/api';
 import type { Id } from '@fomo/backend/convex/_generated/dataModel';
-import { useMutation } from 'convex/react';
+import { useMutation, useQuery } from 'convex/react';
 import { FunctionReturnType } from 'convex/server';
 import { useRouter } from 'expo-router';
+import type { ComponentProps, ReactNode } from 'react';
 import { useState } from 'react';
-import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, Pressable, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 
 type ProfilePageProps = {
   profile: NonNullable<FunctionReturnType<typeof api.users.getCurrentProfile>>;
@@ -30,6 +33,8 @@ type ProfilePageProps = {
   topPaddingClassName?: string;
   bioFallback?: string;
   mediaFeedPathname?: string;
+  viewerUserId?: Id<'users'>;
+  profileAction?: ReactNode;
 };
 
 type ProfileStateScreenProps = {
@@ -55,6 +60,42 @@ export function ProfileStateScreen({
   );
 }
 
+function ProfileIconAction({
+  accessibilityLabel,
+  className,
+  disabled,
+  iconName,
+  iconColor,
+  onPress,
+}: {
+  accessibilityLabel: string;
+  className?: string;
+  disabled?: boolean;
+  iconName: ComponentProps<typeof MaterialIcons>['name'];
+  iconColor: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      className={cn(
+        'size-12 items-center justify-center rounded-full bg-card shadow-sm',
+        className
+      )}
+      disabled={disabled}
+      hitSlop={10}
+      style={({ pressed }) => [
+        pressed && { opacity: 0.9, transform: [{ scale: 0.96 }] },
+        disabled && { opacity: 0.5 },
+      ]}
+      onPress={onPress}
+    >
+      <MaterialIcons name={iconName} size={20} color={iconColor} />
+    </Pressable>
+  );
+}
+
 export function ProfilePage({
   profile,
   feedPosts,
@@ -65,13 +106,26 @@ export function ProfilePage({
   topPaddingClassName = 'pt-20',
   bioFallback,
   mediaFeedPathname = '/profile/media-feed',
+  viewerUserId,
+  profileAction,
 }: ProfilePageProps) {
   const userId = profile.user._id;
   const theme = useAppTheme();
   const router = useRouter();
+  const { isSignedIn } = useUser();
   const { isGuestMode } = useGuest();
   const togglePostLike = useMutation(api.likes.togglePostLike);
+  const sendFriendRequest = useMutation(api.friends.sendFriendRequest);
+  const acceptFriendRequest = useMutation(api.friends.acceptFriendRequest);
+  const cancelFriendRequest = useMutation(api.friends.cancelFriendRequest);
+  const declineFriendRequest = useMutation(api.friends.declineFriendRequest);
   const [activeTab, setActiveTab] = useState<'feed' | 'media'>('feed');
+  const [isSendingFriendRequest, setIsSendingFriendRequest] = useState(false);
+  const [isUpdatingFriendship, setIsUpdatingFriendship] = useState(false);
+  const friendship = useQuery(
+    api.friends.getFriendshipStatusForUser,
+    isSignedIn && viewerUserId && viewerUserId !== userId ? { otherUserId: userId } : 'skip'
+  );
 
   function handlePressGridItem(item: GridMediaItem) {
     router.push({
@@ -88,6 +142,51 @@ export function ProfilePage({
       mediaId: p.mediaIds[0] as Id<'_storage'>,
     }));
   const profileBio = profile.user.bio ?? bioFallback;
+  const relationshipStatus = friendship?.status;
+
+  async function handleSendFriendRequest() {
+    if (!viewerUserId || viewerUserId === userId || isSendingFriendRequest) {
+      return;
+    }
+
+    setIsSendingFriendRequest(true);
+    try {
+      await sendFriendRequest({ recipientId: userId });
+    } catch (error) {
+      console.error('Failed to send friend request', error);
+      Alert.alert('Unable to send request', error instanceof Error ? error.message : 'Try again.');
+    } finally {
+      setIsSendingFriendRequest(false);
+    }
+  }
+
+  async function handleRespondToFriendRequest(action: 'accept' | 'decline') {
+    if (!viewerUserId || viewerUserId === userId || isUpdatingFriendship) {
+      return;
+    }
+
+    setIsUpdatingFriendship(true);
+    try {
+      if (action === 'accept') {
+        await acceptFriendRequest({ requesterId: userId });
+      } else {
+        await declineFriendRequest({ requesterId: userId });
+      }
+    } catch (error) {
+      console.error(`Failed to ${action} friend request`, error);
+      Alert.alert(
+        'Unable to update request',
+        error instanceof Error ? error.message : 'Try again.'
+      );
+    } finally {
+      setIsUpdatingFriendship(false);
+    }
+  }
+
+  const showIncomingFriendRequestActions =
+    viewerUserId && viewerUserId !== userId && relationshipStatus === 'pending_received';
+  const showHeaderFriendAction =
+    viewerUserId && viewerUserId !== userId && relationshipStatus !== 'pending_received';
 
   return (
     <Screen className="flex-1">
@@ -112,16 +211,73 @@ export function ProfilePage({
                   <Text className="text-sm text-muted-foreground">{profile.user.displayName}</Text>
                 ) : null}
               </View>
-              {onPressSettings ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onPress={onPressSettings}
-                  className="-mr-3 rounded-full"
-                  accessibilityLabel="Open settings"
-                >
-                  <MaterialIcons name="settings" size={22} color={theme.mutedText} />
-                </Button>
+              {profileAction || showHeaderFriendAction || onPressSettings ? (
+                <View className="-mr-3 flex-row items-center gap-1">
+                  {profileAction ? <View>{profileAction}</View> : null}
+                  {showHeaderFriendAction ? (
+                    <ProfileIconAction
+                      accessibilityLabel={
+                        relationshipStatus === 'pending_sent'
+                          ? 'Remove pending friend request'
+                          : relationshipStatus === 'accepted'
+                            ? 'Friends'
+                            : 'Add friend'
+                      }
+                      disabled={
+                        relationshipStatus === undefined ||
+                        relationshipStatus === 'accepted' ||
+                        isSendingFriendRequest ||
+                        isUpdatingFriendship
+                      }
+                      iconName={
+                        relationshipStatus === 'pending_sent'
+                          ? 'person-remove'
+                          : relationshipStatus === 'accepted'
+                            ? 'people'
+                            : 'person-add-alt-1'
+                      }
+                      iconColor={theme.tint}
+                      onPress={() => {
+                        if (relationshipStatus === 'pending_sent') {
+                          void (async () => {
+                            if (isUpdatingFriendship) {
+                              return;
+                            }
+
+                            setIsUpdatingFriendship(true);
+                            try {
+                              await cancelFriendRequest({ recipientId: userId });
+                            } catch (error) {
+                              console.error('Failed to cancel friend request', error);
+                              Alert.alert(
+                                'Unable to remove request',
+                                error instanceof Error ? error.message : 'Try again.'
+                              );
+                            } finally {
+                              setIsUpdatingFriendship(false);
+                            }
+                          })();
+                          return;
+                        }
+
+                        if (relationshipStatus === 'none') {
+                          void handleSendFriendRequest();
+                        }
+                      }}
+                    />
+                  ) : null}
+                  {onPressSettings ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onPress={onPressSettings}
+                      className="rounded-full"
+                      accessibilityLabel="Open settings"
+                    >
+                      <MaterialIcons name="settings" size={22} color={theme.mutedText} />
+                    </Button>
+                  ) : null}
+                </View>
               ) : null}
             </View>
             {profileBio ? (
@@ -143,6 +299,31 @@ export function ProfilePage({
               />
             </View>
           </View>
+          {showIncomingFriendRequestActions ? (
+            <View className="mt-4 flex-row gap-3">
+              <Button
+                className="flex-1"
+                onPress={() => {
+                  void handleRespondToFriendRequest('accept');
+                }}
+                disabled={isUpdatingFriendship}
+                accessibilityLabel="Accept friend request"
+              >
+                <ButtonText>{isUpdatingFriendship ? 'Updating...' : 'Accept'}</ButtonText>
+              </Button>
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onPress={() => {
+                  void handleRespondToFriendRequest('decline');
+                }}
+                disabled={isUpdatingFriendship}
+                accessibilityLabel="Decline friend request"
+              >
+                <ButtonText variant="secondary">Decline</ButtonText>
+              </Button>
+            </View>
+          ) : null}
         </View>
 
         {/* TODO :: SEE WHAT TO DO HERE */}

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as events_ingest from "../events/ingest.js";
 import type * as events_mutations from "../events/mutations.js";
 import type * as events_queries from "../events/queries.js";
 import type * as files from "../files.js";
+import type * as friends from "../friends.js";
 import type * as likes from "../likes.js";
 import type * as posts from "../posts.js";
 import type * as seed from "../seed.js";
@@ -47,6 +48,7 @@ declare const fullApi: ApiFromModules<{
   "events/mutations": typeof events_mutations;
   "events/queries": typeof events_queries;
   files: typeof files;
+  friends: typeof friends;
   likes: typeof likes;
   posts: typeof posts;
   seed: typeof seed;

--- a/packages/backend/convex/friends.ts
+++ b/packages/backend/convex/friends.ts
@@ -1,0 +1,267 @@
+import { v } from 'convex/values';
+
+import type { Doc, Id } from './_generated/dataModel';
+import { mutation, query, type QueryCtx } from './_generated/server';
+import { __backend_only_getAndAuthenticateCurrentConvexUser } from './auth';
+
+type FriendshipDoc = Doc<'friends'>;
+type FriendshipStatus = 'self' | 'none' | 'pending_sent' | 'pending_received' | 'accepted';
+
+async function serializeFriendUser(ctx: QueryCtx, userId: Id<'users'>, requestedAt: number) {
+  const user = await ctx.db.get(userId);
+  if (!user) {
+    return null;
+  }
+
+  return {
+    id: user._id,
+    username: user.username,
+    displayName: user.displayName,
+    avatarUrl: user.avatarUrl,
+    requestedAt,
+  };
+}
+
+async function getFriendshipsForPair(
+  ctx: QueryCtx,
+  requesterId: Id<'users'>,
+  recipientId: Id<'users'>
+) {
+  const [direct, reverse] = await Promise.all([
+    ctx.db
+      .query('friends')
+      .withIndex('by_recipientId_requesterId', (q) =>
+        q.eq('recipientId', recipientId).eq('requesterId', requesterId)
+      )
+      .collect(),
+    ctx.db
+      .query('friends')
+      .withIndex('by_recipientId_requesterId', (q) =>
+        q.eq('recipientId', requesterId).eq('requesterId', recipientId)
+      )
+      .collect(),
+  ]);
+
+  return { direct, reverse };
+}
+
+function pickFriendship(friendships: FriendshipDoc[]) {
+  return (
+    friendships.find((friendship) => friendship.status === 'accepted') ??
+    friendships.find((friendship) => friendship.status === 'pending') ??
+    friendships[0] ??
+    null
+  );
+}
+
+function getFriendshipStatus(
+  direct: FriendshipDoc[],
+  reverse: FriendshipDoc[],
+  currentUserId: Id<'users'>,
+  otherUserId: Id<'users'>
+): FriendshipStatus {
+  if (currentUserId === otherUserId) {
+    return 'self';
+  }
+
+  const directFriendship = pickFriendship(direct);
+  if (directFriendship?.status === 'accepted') {
+    return 'accepted';
+  }
+  if (directFriendship?.status === 'pending') {
+    return 'pending_sent';
+  }
+
+  const reverseFriendship = pickFriendship(reverse);
+  if (reverseFriendship?.status === 'accepted') {
+    return 'accepted';
+  }
+  if (reverseFriendship?.status === 'pending') {
+    return 'pending_received';
+  }
+
+  return 'none';
+}
+
+export const getFriendshipStatusForUser = query({
+  args: { otherUserId: v.id('users') },
+  handler: async (ctx, { otherUserId }) => {
+    const user = await __backend_only_getAndAuthenticateCurrentConvexUser(ctx);
+    const { direct, reverse } = await getFriendshipsForPair(ctx, user._id, otherUserId);
+
+    return {
+      status: getFriendshipStatus(direct, reverse, user._id, otherUserId),
+    };
+  },
+});
+
+export const sendFriendRequest = mutation({
+  args: { recipientId: v.id('users') },
+  handler: async (ctx, { recipientId }) => {
+    const user = await __backend_only_getAndAuthenticateCurrentConvexUser(ctx);
+    const requesterId = user._id;
+
+    if (requesterId === recipientId) {
+      throw new Error('You cannot send a friend request to yourself');
+    }
+
+    const recipient = await ctx.db.get(recipientId);
+    if (!recipient) {
+      throw new Error('User not found');
+    }
+
+    const { direct, reverse } = await getFriendshipsForPair(ctx, requesterId, recipientId);
+    const status = getFriendshipStatus(direct, reverse, requesterId, recipientId);
+
+    if (status === 'accepted' || status === 'pending_sent' || status === 'pending_received') {
+      return { status };
+    }
+
+    const existing = pickFriendship(direct) ?? pickFriendship(reverse);
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        requesterId,
+        recipientId,
+        status: 'pending',
+      });
+      return { status: 'pending_sent' as const };
+    }
+
+    await ctx.db.insert('friends', {
+      requesterId,
+      recipientId,
+      status: 'pending',
+    });
+
+    return { status: 'pending_sent' as const };
+  },
+});
+
+export const acceptFriendRequest = mutation({
+  args: { requesterId: v.id('users') },
+  handler: async (ctx, { requesterId }) => {
+    const user = await __backend_only_getAndAuthenticateCurrentConvexUser(ctx);
+
+    const pendingRequest = await ctx.db
+      .query('friends')
+      .withIndex('by_recipientId_requesterId', (q) =>
+        q.eq('recipientId', user._id).eq('requesterId', requesterId)
+      )
+      .filter((q) => q.eq(q.field('status'), 'pending'))
+      .first();
+
+    if (!pendingRequest) {
+      throw new Error('Friend request not found');
+    }
+
+    await ctx.db.patch(pendingRequest._id, { status: 'accepted' });
+    return { status: 'accepted' as const };
+  },
+});
+
+export const declineFriendRequest = mutation({
+  args: { requesterId: v.id('users') },
+  handler: async (ctx, { requesterId }) => {
+    const user = await __backend_only_getAndAuthenticateCurrentConvexUser(ctx);
+
+    const pendingRequest = await ctx.db
+      .query('friends')
+      .withIndex('by_recipientId_requesterId', (q) =>
+        q.eq('recipientId', user._id).eq('requesterId', requesterId)
+      )
+      .filter((q) => q.eq(q.field('status'), 'pending'))
+      .first();
+
+    if (!pendingRequest) {
+      throw new Error('Friend request not found');
+    }
+
+    await ctx.db.patch(pendingRequest._id, { status: 'rejected' });
+    return { status: 'rejected' as const };
+  },
+});
+
+export const cancelFriendRequest = mutation({
+  args: { recipientId: v.id('users') },
+  handler: async (ctx, { recipientId }) => {
+    const user = await __backend_only_getAndAuthenticateCurrentConvexUser(ctx);
+
+    const pendingRequest = await ctx.db
+      .query('friends')
+      .withIndex('by_recipientId_requesterId', (q) =>
+        q.eq('recipientId', recipientId).eq('requesterId', user._id)
+      )
+      .filter((q) => q.eq(q.field('status'), 'pending'))
+      .first();
+
+    if (!pendingRequest) {
+      throw new Error('Pending friend request not found');
+    }
+
+    await ctx.db.patch(pendingRequest._id, { status: 'rejected' });
+    return { status: 'none' as const };
+  },
+});
+
+export const getPendingFriendRequests = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await __backend_only_getAndAuthenticateCurrentConvexUser(ctx);
+    const requests = await ctx.db
+      .query('friends')
+      .withIndex('by_recipientId', (q) => q.eq('recipientId', user._id))
+      .filter((q) => q.eq(q.field('status'), 'pending'))
+      .collect();
+
+    const requestUsers = await Promise.all(
+      requests.map((request) =>
+        serializeFriendUser(ctx, request.requesterId, request._creationTime)
+      )
+    );
+
+    return requestUsers
+      .filter((request): request is NonNullable<typeof request> => request !== null)
+      .sort((a, b) => b.requestedAt - a.requestedAt);
+  },
+});
+
+export const getFriendRequests = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await __backend_only_getAndAuthenticateCurrentConvexUser(ctx);
+    const [receivedRequests, sentRequests] = await Promise.all([
+      ctx.db
+        .query('friends')
+        .withIndex('by_recipientId', (q) => q.eq('recipientId', user._id))
+        .filter((q) => q.eq(q.field('status'), 'pending'))
+        .collect(),
+      ctx.db
+        .query('friends')
+        .withIndex('by_requesterId', (q) => q.eq('requesterId', user._id))
+        .filter((q) => q.eq(q.field('status'), 'pending'))
+        .collect(),
+    ]);
+
+    const [received, sent] = await Promise.all([
+      Promise.all(
+        receivedRequests.map((request) =>
+          serializeFriendUser(ctx, request.requesterId, request._creationTime)
+        )
+      ),
+      Promise.all(
+        sentRequests.map((request) =>
+          serializeFriendUser(ctx, request.recipientId, request._creationTime)
+        )
+      ),
+    ]);
+
+    return {
+      received: received
+        .filter((request): request is NonNullable<typeof request> => request !== null)
+        .sort((a, b) => b.requestedAt - a.requestedAt),
+      sent: sent
+        .filter((request): request is NonNullable<typeof request> => request !== null)
+        .sort((a, b) => b.requestedAt - a.requestedAt),
+    };
+  },
+});


### PR DESCRIPTION
## Summary

Adds end-to-end friend request support to the mobile app and Convex backend, including sending, accepting, declining, and canceling requests. It also surfaces friend actions on profile pages and adds a dedicated friend requests screen for reviewing incoming and outgoing pending requests.

---

## Why is this change necessary?

Users could not actually add each other as friends from profile surfaces, and there was no mobile flow for managing pending requests. This change introduces the missing backend mutations/queries and wires them into profile and request-management UI so friendships can be created and managed in-app.

---

## Changes
Main changes introduced in this PR:
- Added new Convex friend request APIs in packages/backend/convex/friends.ts
- Added friendship state lookup for visited profiles
- Added mutations to send, accept, decline, and cancel friend requests
- Added queries for received and sent pending friend requests
- Updated profile pages to show contextual friend actions for non-self users
- Enabled the same friend actions on profiles opened from event attendee flows
- Added a dedicated Friend Requests screen in mobile profile routes
- Added a header icon entry point for friend requests on the current user profile
- Updated request rows to match existing FriendCell styling with right-side action accessories
- Extended FriendCell to support optional right-side accessories and border control

---

## UML Diagram 

```mermaid
graph TD
A[View User Profile] --> B[Query Friendship Status]
B --> C{Relationship State}
C -->|none| D[Send Friend Request]
C -->|pending_sent| E[Cancel Request]
C -->|pending_received| F[Accept or Decline]
C -->|accepted| G[Show Friends State]
H[Profile Requests Screen] --> I[Query Sent and Received Requests]
I --> J[Accept / Decline / Remove]
J --> K[Convex friends mutations]
K --> L[friends table]
```

## Testing

1. Run pnpm convex:codegen
2. Run pnpm --filter @fomo/backend typecheck
3. Run pnpm --filter @fomo/mobile typecheck
4. Open your own profile and confirm the friend requests icon appears in the top-right
5. Open another user’s profile and verify Add Friend appears when no relationship exists
6. Send a friend request and verify the profile action changes to a removable pending state
7. Open the Friend Requests page and verify both Received and Sent sections render correctly
8. Accept and decline an incoming request and verify the profile/request list updates accordingly
9. Open a user profile from an event attendee list and verify the same friend actions appear there

## Screenshots / UI Changes

- Profile header now includes a friend requests icon with a badge for received pending requests
- Non-self profile pages now show contextual friendship actions
- New mobile Friend Requests page includes separate received and sent request sections
Notes / Acknowledgments (optional)
- Current pending-request ordering is based on the underlying record creation time, so re-sent requests may not appear as newest if an old record is reused.
- Request queries currently filter by status after index lookup; adding composite status indexes would improve scalability if this table grows significantly.