### PR TITLE
Fix/http fix

### DIFF
--- a/packages/backend/convex/data_ml/http.ts
+++ b/packages/backend/convex/data_ml/http.ts
@@ -1,3 +1,4 @@
+import type { HttpRouter } from 'convex/server';
 import { internal } from '../_generated/api';
 import { Id, TableNames } from '../_generated/dataModel';
 import { httpAction } from '../_generated/server';
@@ -10,7 +11,7 @@ function validateSecret(req: Request): Response | null {
   return null;
 }
 
-export function registerDataMlRoutes(http: httpRouter) {
+export function registerDataMlRoutes(http: HttpRouter) {
   http.route({
     path: '/data-ml/get-by-user-id',
     method: 'GET',

--- a/packages/backend/convex/data_ml/http.ts
+++ b/packages/backend/convex/data_ml/http.ts
@@ -1,9 +1,6 @@
-import { httpRouter } from 'convex/server';
 import { internal } from '../_generated/api';
 import { Id, TableNames } from '../_generated/dataModel';
 import { httpAction } from '../_generated/server';
-
-const http = httpRouter();
 
 function validateSecret(req: Request): Response | null {
   const secret = req.headers.get('x-cron-secret');
@@ -13,232 +10,238 @@ function validateSecret(req: Request): Response | null {
   return null;
 }
 
-http.route({
-  path: '/data-ml/get-by-user-id',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+export function registerDataMlRoutes(http: httpRouter) {
+  http.route({
+    path: '/data-ml/get-by-user-id',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const userId = searchParams.get('userId') as unknown as Id<'users'>;
+      const { searchParams } = new URL(req.url);
+      const userId = searchParams.get('userId') as unknown as Id<'users'>;
 
-    const result = await ctx.runQuery(internal.data_ml.eventRec.getByUserId, { userId });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.eventRec.getByUserId, { userId });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/get-by-event-id',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/get-by-event-id',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const eventId = searchParams.get('eventId') as unknown as Id<'events'>;
+      const { searchParams } = new URL(req.url);
+      const eventId = searchParams.get('eventId') as unknown as Id<'events'>;
 
-    const result = await ctx.runQuery(internal.data_ml.eventRec.getByEventId, { eventId });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.eventRec.getByEventId, { eventId });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/upsert-user-tag-weights',
-  method: 'POST',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/upsert-user-tag-weights',
+    method: 'POST',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const body = await req.json();
-    await ctx.runMutation(internal.data_ml.eventRec.upsertUserTagWeights, body);
-    return new Response('OK', { status: 200 });
-  }),
-});
+      const body = await req.json();
+      await ctx.runMutation(internal.data_ml.eventRec.upsertUserTagWeights, body);
+      return new Response('OK', { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/get-user-tag-weights',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/get-user-tag-weights',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const userIds = searchParams.getAll('userId') as unknown as Id<'users'>[];
+      const { searchParams } = new URL(req.url);
+      const userIds = searchParams.getAll('userId') as unknown as Id<'users'>[];
 
-    const result = await ctx.runQuery(internal.data_ml.eventRec.getUserTagWeights, {
-      userIDs: userIds,
-    });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.eventRec.getUserTagWeights, {
+        userIDs: userIds,
+      });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/get-user-tag-weights-timestamp',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/get-user-tag-weights-timestamp',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
+      const { searchParams } = new URL(req.url);
 
-    const userId = searchParams.get('userId') as unknown as Id<'users'>;
-    const numTags = Number(searchParams.get('numTags'));
+      const userId = searchParams.get('userId') as unknown as Id<'users'>;
+      const numTags = Number(searchParams.get('numTags'));
 
-    const result = await ctx.runQuery(internal.data_ml.eventRec.getUserTagWeightsWithTimestamp, {
-      userId,
-      numTags,
-    });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.eventRec.getUserTagWeightsWithTimestamp, {
+        userId,
+        numTags,
+      });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/get-interactions',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/get-interactions',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const userId = searchParams.get('userId') as unknown as Id<'users'>;
-    const sinceMsRaw = searchParams.get('sinceMs');
-    const queryArgs = sinceMsRaw !== null ? { userId, sinceMs: Number(sinceMsRaw) } : { userId };
+      const { searchParams } = new URL(req.url);
+      const userId = searchParams.get('userId') as unknown as Id<'users'>;
+      const sinceMsRaw = searchParams.get('sinceMs');
+      const queryArgs = sinceMsRaw !== null ? { userId, sinceMs: Number(sinceMsRaw) } : { userId };
 
-    const result = await ctx.runQuery(internal.data_ml.eventRec.getInteractionsByUserId, queryArgs);
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(
+        internal.data_ml.eventRec.getInteractionsByUserId,
+        queryArgs
+      );
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/upsert-event-recs',
-  method: 'POST',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/upsert-event-recs',
+    method: 'POST',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const body = await req.json();
-    await ctx.runMutation(internal.data_ml.eventRec.upsertEventRecs, body);
-    return new Response('OK', { status: 200 });
-  }),
-});
+      const body = await req.json();
+      await ctx.runMutation(internal.data_ml.eventRec.upsertEventRecs, body);
+      return new Response('OK', { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/upsert-friend-recs',
-  method: 'POST',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/upsert-friend-recs',
+    method: 'POST',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const body = await req.json();
-    await ctx.runMutation(internal.data_ml.friendRecs.upsert, body);
-    return new Response('OK', { status: 200 });
-  }),
-});
+      const body = await req.json();
+      await ctx.runMutation(internal.data_ml.friendRecs.upsert, body);
+      return new Response('OK', { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/friend-exists',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/friend-exists',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const userAId = searchParams.get('userAId') as unknown as Id<'users'>;
-    const userBId = searchParams.get('userBId') as unknown as Id<'users'>;
+      const { searchParams } = new URL(req.url);
+      const userAId = searchParams.get('userAId') as unknown as Id<'users'>;
+      const userBId = searchParams.get('userBId') as unknown as Id<'users'>;
 
-    const result = await ctx.runQuery(internal.data_ml.friends.friendExists, { userAId, userBId });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.friends.friendExists, {
+        userAId,
+        userBId,
+      });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/get-friend-ids',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/get-friend-ids',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const userId = searchParams.get('userId') as unknown as Id<'users'>;
+      const { searchParams } = new URL(req.url);
+      const userId = searchParams.get('userId') as unknown as Id<'users'>;
 
-    const result = await ctx.runQuery(internal.data_ml.friends.getFriendIds, { userId });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.friends.getFriendIds, { userId });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/query-all',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/query-all',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const table_name = searchParams.get('table_name') as unknown as TableNames;
+      const { searchParams } = new URL(req.url);
+      const table_name = searchParams.get('table_name') as unknown as TableNames;
 
-    const result = await ctx.runQuery(internal.data_ml.universal.queryAll, { table_name });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.universal.queryAll, { table_name });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/user-exists',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/user-exists',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const userId = searchParams.get('userId') as unknown as Id<'users'>;
+      const { searchParams } = new URL(req.url);
+      const userId = searchParams.get('userId') as unknown as Id<'users'>;
 
-    const result = await ctx.runQuery(internal.data_ml.users.userExists, { userId });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.users.userExists, { userId });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/get-all-user-ids',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/get-all-user-ids',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const result = await ctx.runQuery(internal.data_ml.users.getAllUserIds, {});
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.users.getAllUserIds, {});
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/get-name-by-id',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/get-name-by-id',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const userId = searchParams.get('userId') as unknown as Id<'users'>;
+      const { searchParams } = new URL(req.url);
+      const userId = searchParams.get('userId') as unknown as Id<'users'>;
 
-    const result = await ctx.runQuery(internal.data_ml.users.getNameById, { userId });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
+      const result = await ctx.runQuery(internal.data_ml.users.getNameById, { userId });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 
-http.route({
-  path: '/data-ml/get-preferred-tags-by-user-id',
-  method: 'GET',
-  handler: httpAction(async (ctx, req) => {
-    const authError = validateSecret(req);
-    if (authError) return authError;
+  http.route({
+    path: '/data-ml/get-preferred-tags-by-user-id',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
 
-    const { searchParams } = new URL(req.url);
-    const userIds = searchParams.getAll('userId') as unknown as Id<'users'>[];
+      const { searchParams } = new URL(req.url);
+      const userIds = searchParams.getAll('userId') as unknown as Id<'users'>[];
 
-    const result = await ctx.runQuery(internal.data_ml.eventRec.getPreferredTagsByUserId, {
-      userIds,
-    });
-    return new Response(JSON.stringify(result), { status: 200 });
-  }),
-});
-
-export default http;
+      const result = await ctx.runQuery(internal.data_ml.eventRec.getPreferredTagsByUserId, {
+        userIds,
+      });
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
+}

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -5,8 +5,11 @@ import { Webhook } from 'svix';
 
 import { internal } from './_generated/api';
 import { httpAction } from './_generated/server';
+import { registerDataMlRoutes } from './data_ml/http';
 
 const http = httpRouter();
+
+registerDataMlRoutes(http);
 
 const clerkWebhookHandler = httpAction(async (ctx, request) => {
   console.log('[clerk-webhook] request received', {


### PR DESCRIPTION
<!--
Before submitting this PR:
- Add appropriate labels (feature, bug, refactor, chore, docs, etc.)
- Link any related issues
- Ensure tests/build pass
-->

## Summary

Fixes the issue of HTTP requests for the recommendation engine failing.

---

## Why is this change necessary?

These requests are integral to the recommendation engine.

---

## Changes

Main changes introduced in this PR:
- Introduced `registerDataMlRoutes(http: HttpRouter)` located in `packages/backend/convex/data_ml/http.ts`
- Called the `registerDataMlRoutes` in `packages/backend/convex/http.ts` 
---

## Testing

Step-by-step instructions for reviewers to verify the changes.

1. Run any of the Python scripts