### PR TITLE
Web Privacy, Support Page + Footer

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -24,8 +24,8 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   //TODO decide with team on uppercase letters or not
-  title: 'FOMO',
-  description: 'FOMO web app',
+  title: 'Fomo',
+  description: 'Fomo — Find Out More Often',
 };
 
 export default function RootLayout({

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,14 +1,28 @@
 import { Header } from '@/components/header';
 import { Hero } from '@/components/landing/hero';
 import LandingNoise from '@/components/landing/simplex-noise';
+import Link from 'next/link';
 
 export default function HomePage() {
   return (
     <>
       <Header />
-      <main className="relative mx-auto max-w-screen-2xl px-16 pt-28">
+      <main className="relative mx-auto flex min-h-screen max-w-screen-2xl flex-col px-6 pt-28 md:px-16">
         <Hero />
         <LandingNoise />
+        <footer className="mt-auto border-t border-border/60 py-6">
+          <div className="flex flex-col items-center justify-between gap-3 text-sm text-muted-foreground md:flex-row">
+            <p>Fomo</p>
+            <div className="flex items-center gap-5">
+              <Link href="/privacy" className="transition-colors hover:text-foreground">
+                Privacy
+              </Link>
+              <Link href="/support" className="transition-colors hover:text-foreground">
+                Support
+              </Link>
+            </div>
+          </div>
+        </footer>
       </main>
     </>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function HomePage() {
   return (
     <>
       <Header />
-      <main className="relative mx-auto flex min-h-screen max-w-screen-2xl flex-col px-6 pt-28 md:px-16">
+      <main className="relative isolate mx-auto flex min-h-screen max-w-screen-2xl flex-col px-6 pt-28 md:px-16">
         <Hero />
         <LandingNoise />
         <footer className="mt-auto border-t border-border/60 py-6">

--- a/apps/web/src/app/privacy/constants.ts
+++ b/apps/web/src/app/privacy/constants.ts
@@ -1,0 +1,48 @@
+export const PRIVACY_LAST_UPDATED = 'April 30, 2026';
+
+export const PRIVACY_INTRO =
+  'Fomo is a social platform built around local discovery, events, maps, and shared experiences. This page explains the kinds of information Fomo may collect and how that information may be used when you use the app or related web pages.';
+
+export const PRIVACY_SECTIONS = [
+  {
+    title: 'Information We Collect',
+    body: [
+      'Fomo may collect information you provide directly, including account details, profile information, event details, posts, friend activity, and messages submitted through our support form.',
+      'If you allow location access, Fomo may collect location information to help show nearby events, map activity, and other location-based features.',
+    ],
+  },
+  {
+    title: 'How We Use Information',
+    body: [
+      'We use collected information to operate the app, personalize maps and recommendations, support RSVP and social features, maintain account security, and respond to support requests.',
+      'We may also use service-related data to troubleshoot bugs, improve reliability, and understand how Fomo is being used.',
+    ],
+  },
+  {
+    title: 'Third-Party Services',
+    body: [
+      'Fomo uses third-party infrastructure and services that may process data on our behalf, including Clerk for authentication, Convex for backend data storage and sync, and Mapbox for maps and location-related experiences.',
+      'These providers may process the data needed to deliver their parts of the service under their own terms and privacy practices.',
+    ],
+  },
+  {
+    title: 'Sharing and Disclosure',
+    body: [
+      'Information you choose to post or place on your profile may be visible to other users depending on how the feature is designed in the app.',
+      'We may also disclose information when needed to comply with legal obligations, protect users, enforce our terms, or maintain the security and integrity of Fomo.',
+    ],
+  },
+  {
+    title: 'Your Choices',
+    body: [
+      'You can choose whether to grant location permissions on your device, and you can limit what information you post, upload, or include on your profile.',
+      'If you need help with privacy-related questions or requests, use the support page available on the Fomo website.',
+    ],
+  },
+  {
+    title: 'Contact',
+    body: [
+      'For privacy questions, support requests, or questions about this policy, contact the Fomo team through our support page.',
+    ],
+  },
+] as const;

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,55 @@
+import { Header } from '@/components/header';
+import Link from 'next/link';
+import { PRIVACY_INTRO, PRIVACY_LAST_UPDATED, PRIVACY_SECTIONS } from './constants';
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col px-6 pt-28 pb-12 md:px-10">
+        <section className="rounded-[2rem] border border-border/70 bg-background/80 p-8 shadow-lg backdrop-blur md:p-10">
+          <div className="space-y-3">
+            <p className="text-sm font-medium uppercase tracking-[0.28em] text-muted-foreground">
+              Privacy Policy
+            </p>
+            <h1 className="text-4xl font-semibold tracking-tight text-balance">
+              Fomo Privacy Policy
+            </h1>
+            <p className="text-sm leading-6 text-muted-foreground md:text-base">
+              Last updated: {PRIVACY_LAST_UPDATED}
+            </p>
+            <p className="max-w-3xl text-sm leading-6 text-muted-foreground md:text-base">
+              {PRIVACY_INTRO}
+            </p>
+          </div>
+
+          <div className="mt-8 space-y-8">
+            {PRIVACY_SECTIONS.map((section) => (
+              <section key={section.title} className="space-y-3">
+                <h2 className="text-xl font-semibold tracking-tight">{section.title}</h2>
+                {section.body.map((paragraph) => (
+                  <p
+                    key={paragraph}
+                    className="text-sm leading-6 text-muted-foreground md:text-base"
+                  >
+                    {paragraph}
+                  </p>
+                ))}
+                {section.title === 'Contact' ? (
+                  <p className="text-sm leading-6 text-muted-foreground md:text-base">
+                    <Link
+                      href="/support"
+                      className="underline underline-offset-4 hover:text-foreground"
+                    >
+                      https://fomo-app.dev/support
+                    </Link>
+                  </p>
+                ) : null}
+              </section>
+            ))}
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/app/support/page.tsx
+++ b/apps/web/src/app/support/page.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { api } from '@fomo/backend/convex/_generated/api';
 import { useMutation } from 'convex/react';
 import { MailIcon, MessageSquareIcon } from 'lucide-react';
+import Link from 'next/link';
 import { type FormEvent, useState } from 'react';
 
 const fieldClassName =
@@ -70,6 +71,13 @@ export default function SupportPage() {
             <p className="max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
               Send a quick note and the Fomo team can follow up about account issues, bugs, event
               problems, or anything else you run into.
+            </p>
+            <p className="text-sm leading-6 text-muted-foreground">
+              For information about how Fomo handles data, view our{' '}
+              <Link href="/privacy" className="underline underline-offset-4 hover:text-foreground">
+                privacy policy
+              </Link>
+              .
             </p>
           </div>
 

--- a/apps/web/src/app/support/page.tsx
+++ b/apps/web/src/app/support/page.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { Header } from '@/components/header';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { api } from '@fomo/backend/convex/_generated/api';
+import { useMutation } from 'convex/react';
+import { MailIcon, MessageSquareIcon } from 'lucide-react';
+import { type FormEvent, useState } from 'react';
+
+const fieldClassName =
+  'w-full rounded-2xl border border-border bg-background/70 px-4 py-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50';
+
+export default function SupportPage() {
+  const createSupportRequest = useMutation(api.support.createSupportRequest);
+
+  const [email, setEmail] = useState('');
+  const [description, setDescription] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    const trimmedEmail = email.trim();
+    const trimmedDescription = description.trim();
+
+    if (!trimmedEmail) {
+      setErrorMessage('Enter an email so we can follow up.');
+      return;
+    }
+
+    if (!trimmedDescription) {
+      setErrorMessage('Add a short description of the issue.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage('');
+
+    try {
+      await createSupportRequest({
+        email: trimmedEmail,
+        description: trimmedDescription,
+      });
+      setEmail('');
+      setDescription('');
+      setIsSubmitted(true);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Could not send your request.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Header />
+      <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-center px-6 pt-28 pb-12 md:px-10">
+        <section className="rounded-[2rem] border border-border/70 bg-background/80 p-8 shadow-lg backdrop-blur md:p-10">
+          <div className="space-y-3">
+            <p className="text-sm font-medium uppercase tracking-[0.28em] text-muted-foreground">
+              Fomo Support
+            </p>
+            <h1 className="text-4xl font-semibold tracking-tight text-balance">
+              Tell us what you need help with.
+            </h1>
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
+              Send a quick note and the Fomo team can follow up about account issues, bugs, event
+              problems, or anything else you run into.
+            </p>
+          </div>
+
+          <form className="mt-8 space-y-5" onSubmit={handleSubmit}>
+            <label className="block space-y-2">
+              <span className="text-sm font-medium">Email</span>
+              <div className="relative">
+                <MailIcon className="pointer-events-none absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  placeholder="you@example.com"
+                  className="h-12 rounded-2xl border-border bg-background/70 pl-11"
+                  autoComplete="email"
+                />
+              </div>
+            </label>
+
+            <label className="block space-y-2">
+              <span className="text-sm font-medium">Description</span>
+              <div className="relative">
+                <MessageSquareIcon className="pointer-events-none absolute top-4 left-4 size-4 text-muted-foreground" />
+                <textarea
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  placeholder="Describe the issue, question, or feedback you have for Fomo."
+                  className={`${fieldClassName} min-h-40 resize-y pl-11`}
+                />
+              </div>
+            </label>
+
+            {errorMessage ? <p className="text-sm text-destructive">{errorMessage}</p> : null}
+
+            {isSubmitted ? (
+              <p className="text-sm text-emerald-600 dark:text-emerald-400">
+                Your message was sent. We will follow up at the email you provided.
+              </p>
+            ) : null}
+
+            <Button type="submit" size="lg" className="w-full sm:w-auto" disabled={isSubmitting}>
+              {isSubmitting ? 'Sending...' : 'Send support request'}
+            </Button>
+          </form>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -7,7 +7,7 @@ import { Button } from '../ui/button';
 
 export function Hero() {
   return (
-    <section className="relative flex items-center justify-center h-full mt-20 overflow-hidden flex-col gap-10">
+    <section className="relative z-10 mt-20 flex h-full flex-col items-center justify-center gap-10 overflow-hidden">
       {/* logo */}
       <motion.div
         initial={{ opacity: 0 }}
@@ -69,7 +69,7 @@ export function Hero() {
           delay: 2.2,
           ease: [0.25, 0.46, 0.45, 0.94],
         }}
-        className="flex items-center gap-3"
+        className="relative z-10 flex items-center gap-3"
       >
         <Show when="signed-out">
           <Button size="lg" className="text-xl px-4 py-6" asChild>

--- a/apps/web/src/components/landing/simplex-noise.tsx
+++ b/apps/web/src/components/landing/simplex-noise.tsx
@@ -28,7 +28,7 @@ export default function LandingNoise() {
 
   return (
     <motion.div
-      className={`pointer-events-none fixed w-full h-full bottom-0 right-0 left-0 opacity-90 inset-0
+      className={`pointer-events-none fixed inset-0 -z-10 h-full w-full opacity-90
         lg:mask-[radial-gradient(ellipse_35%_45%_at_50%_100%,white_0%,white_20%,transparent_90%)] 
         mask-[radial-gradient(ellipse_65%_25%_at_50%_90%,white_0%,white_20%,transparent_90%)] 
       `}

--- a/apps/web/src/components/signed-in-status.tsx
+++ b/apps/web/src/components/signed-in-status.tsx
@@ -22,7 +22,7 @@ export function SignedInStatus() {
     return (
       <>
         <h1 className="text-3xl font-semibold tracking-tight text-black dark:text-zinc-50">
-          Welcome to FOMO
+          Welcome to Fomo
         </h1>
         <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
           Sign in with the button in the top right to access your account.

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as http from "../http.js";
 import type * as likes from "../likes.js";
 import type * as posts from "../posts.js";
 import type * as seed from "../seed.js";
+import type * as support from "../support.js";
 import type * as tags from "../tags.js";
 import type * as temp_seed from "../temp_seed.js";
 import type * as users from "../users.js";
@@ -59,6 +60,7 @@ declare const fullApi: ApiFromModules<{
   likes: typeof likes;
   posts: typeof posts;
   seed: typeof seed;
+  support: typeof support;
   tags: typeof tags;
   temp_seed: typeof temp_seed;
   users: typeof users;

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -157,4 +157,9 @@ export default defineSchema({
     userId: v.id('users'),
     eventIds: v.array(v.id('events')),
   }).index('by_userId', ['userId']),
+
+  support: defineTable({
+    email: v.string(),
+    description: v.string(),
+  }),
 });

--- a/packages/backend/convex/support.ts
+++ b/packages/backend/convex/support.ts
@@ -1,0 +1,27 @@
+import { v } from 'convex/values';
+
+import { mutation } from './_generated/server';
+
+export const createSupportRequest = mutation({
+  args: {
+    email: v.string(),
+    description: v.string(),
+  },
+  handler: async (ctx, { email, description }) => {
+    const normalizedEmail = email.trim().toLowerCase();
+    const normalizedDescription = description.trim();
+
+    if (!normalizedEmail) {
+      throw new Error('Email is required.');
+    }
+
+    if (!normalizedDescription) {
+      throw new Error('Description is required.');
+    }
+
+    return await ctx.db.insert('support', {
+      email: normalizedEmail,
+      description: normalizedDescription,
+    });
+  },
+});


### PR DESCRIPTION
## Summary

Adds basic public Support and Privacy pages for the web app so App Store Connect has valid policy and support URLs. Also adds a minimal Convex-backed support form and footer links on the landing page for easier access.

---

## Why is this change necessary?
App Store submission requires a privacy policy URL and a support URL. Fomo did not have dedicated public pages for either, so this change adds the minimum required experience and makes those links accessible from the landing page.

---

## Changes

- Added a public /support page with a basic form for email and description
- Added a Convex support table and mutation to store support submissions
- Added a public /privacy page with basic privacy policy content
- Moved privacy copy into apps/web/src/app/privacy/constants.ts
- Added landing page footer links to Privacy and Support
- Fixed landing page layering so the hero buttons stay above the shader