### PR TITLE
feat: Create queries to get events from the externalEvents table

### DIFF
--- a/packages/backend/convex/events/attendance.ts
+++ b/packages/backend/convex/events/attendance.ts
@@ -35,7 +35,9 @@ function countsAsAttendee(attendance: Doc<'attendance'>) {
   return (attendance.status ?? 'going') === 'going';
 }
 
-export async function getAttendeeCount(ctx: QueryCtx, eventId: Id<'events'>) {
+type AttendanceEventId = Id<'events'> | Id<'externalEvents'>;
+
+export async function getAttendeeCount(ctx: QueryCtx, eventId: AttendanceEventId) {
   const attendees = await ctx.db
     .query('attendance')
     .withIndex('by_event', (q) => q.eq('eventId', eventId))

--- a/packages/backend/convex/events/queries.ts
+++ b/packages/backend/convex/events/queries.ts
@@ -46,6 +46,30 @@ async function serializeEvent(ctx: QueryCtx, event: Doc<'events'>, recommendatio
   };
 }
 
+async function serializeExternalEvent(
+  ctx: QueryCtx,
+  event: Doc<'externalEvents'>,
+  recommendationScore?: number
+) {
+  const attendeeCount = await getAttendeeCount(ctx, event._id);
+
+  return {
+    id: event._id,
+    externalKey: event.externalKey,
+    name: event.name,
+    caption: event.caption,
+    organization: event.organization,
+    tags: [],
+    location: event.location,
+    attendeeCount,
+    startDate: event.startDate,
+    endDate: event.endDate,
+    mediaId: null,
+    hostIds: [],
+    recommendationScore,
+  };
+}
+
 async function serializeEventFeedPost(
   ctx: QueryCtx,
   post: Doc<'posts'>,
@@ -107,6 +131,32 @@ export const getEventById = query({
     }
 
     return await serializeEvent(ctx, event);
+  },
+});
+
+export const getExternalEvents = query({
+  args: {},
+  handler: async (ctx) => {
+    const [, guestMode] = await __backend_only_guestOrAuthenticatedUser(ctx);
+
+    const events = await ctx.db.query('externalEvents').withIndex('by_startDate').collect();
+    return await Promise.all(
+      events.map((event, index) =>
+        serializeExternalEvent(ctx, event, guestMode ? undefined : 1 / (index + 1))
+      )
+    );
+  },
+});
+
+export const getExternalEventsById = query({
+  args: { eventId: v.id('externalEvents') },
+  handler: async (ctx, { eventId }) => {
+    const event = await ctx.db.get(eventId);
+    if (!event) {
+      return null;
+    }
+
+    return await serializeExternalEvent(ctx, event);
   },
 });
 


### PR DESCRIPTION
## Summary

Adds two new Convex queries — getExternalEvents and getExternalEventsById — and a serializeExternalEvent helper that shapes externalEvents documents into the same response format used by existing internal event queries. A union type AttendanceEventId is also introduced in attendance.ts so that getAttendeeCount can be called with either an events or externalEvents ID, enabling attendance counts to work seamlessly across both event sources.

---

## Why is this change necessary?

The externalEvents table has been populated by the Ticketmaster ingestion pipeline, but there was no way for the frontend to query or display those events. Without these queries, ingested external events were effectively write-only — stored in the DB but unreachable by any client. This change exposes them through the standard Convex query interface and ensures they surface with the same shape as internal events so the UI doesn't need to handle two different data formats.

---

## Changes

- packages/backend/convex/events/queries.ts
  - Added serializeExternalEvent(ctx, event, recommendationScore?) — maps a Doc<'externalEvents'> to a serialized response object with fields: id, externalKey, name, caption, organization, tags: [], location, attendeeCount (fetched via getAttendeeCount), startDate, endDate, mediaId: null, hostIds: [], and recommendationScore.
  - Added getExternalEvents Convex query — no args; authenticates caller via __backend_only_guestOrAuthenticatedUser, fetches all external events ordered by by_startDate index, and serializes each with a decaying recommendation score (1 / (index + 1)). Guest users receive no recommendation score (undefined).
  - Added getExternalEventsById Convex query — accepts eventId: Id<'externalEvents'>; fetches a single document via ctx.db.get, returns null if not found, otherwise returns the serialized event (no recommendation score).

- packages/backend/convex/events/attendance.ts
  - Added AttendanceEventId union type: Id<'events'> | Id<'externalEvents'>.
  - Updated getAttendeeCount signature from eventId: Id<'events'> to eventId: AttendanceEventId, allowing attendance counts to be fetched for external events without duplicating the query logic.

---

## UML Diagram

<img width="611" height="675" alt="image" src="https://github.com/user-attachments/assets/308e006c-c036-44f4-9fa9-dd95dba17db4" />

## Testing

1. Verify getExternalEvents returns a populated list
```bash
pnpm exec convex run events/queries:getExternalEvents
```
2. Copy one id from the result or the db and verify getExternalEventsById
```bash
pnpm exec convex run events/queries:getExternalEventsById '{"eventId":"<copied_id>"}'
```

## Notes

- tags, mediaId, and hostIds are hardcoded to [], null, and [] respectively in serializeExternalEvent, external events ingested from Ticketmaster don't carry these fields natively. My next PR will likely add tags to ingested events.