### PR TITLE
Delete Account on Mobile

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile/settings.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/settings.tsx
@@ -1,23 +1,32 @@
 import { Button, ButtonText } from '@/components/ui/button';
 import { DrawerModal } from '@/components/ui/drawer';
+import { AuthInput } from '@/features/auth/components/input';
 import { signOutClerkExpo } from '@/features/auth/utils/clerk-sign-out';
 import { InterestsPicker } from '@/features/profile/components/interests-picker';
 import { ThemePicker } from '@/features/profile/components/theme-picker';
 import { useAppTheme } from '@/lib/use-app-theme';
-import { useClerk } from '@clerk/expo';
+import { useClerk, useUser } from '@clerk/expo';
 import { Ionicons } from '@expo/vector-icons';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
+
+const DELETE_ACCOUNT_CONFIRMATION = 'Delete account';
 
 export default function SettingsScreen() {
   const clerk = useClerk();
+  const { user } = useUser();
   const router = useRouter();
   const theme = useAppTheme();
 
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false);
+  const [deleteAccountOpen, setDeleteAccountOpen] = useState(false);
+  const [deleteConfirmation, setDeleteConfirmation] = useState('');
   const [interestsOpen, setInterestsOpen] = useState(false);
+
+  const canDeleteAccount = deleteConfirmation.trim() === DELETE_ACCOUNT_CONFIRMATION;
 
   async function handleLogout() {
     if (isSigningOut) return;
@@ -26,6 +35,28 @@ export default function SettingsScreen() {
       await signOutClerkExpo(clerk);
     } finally {
       setIsSigningOut(false);
+    }
+  }
+
+  async function handleDeleteAccount() {
+    if (isDeletingAccount || !canDeleteAccount || !user) return;
+
+    setIsDeletingAccount(true);
+
+    try {
+      await user.delete();
+      setDeleteAccountOpen(false);
+      setDeleteConfirmation('');
+      await signOutClerkExpo(clerk);
+      router.replace('/(auth)/welcome' as never);
+      Alert.alert('Account deleted', 'Your account has been permanently deleted.');
+    } catch (error) {
+      Alert.alert(
+        'Unable to delete account',
+        error instanceof Error ? error.message : 'Please try again.'
+      );
+    } finally {
+      setIsDeletingAccount(false);
     }
   }
 
@@ -59,6 +90,19 @@ export default function SettingsScreen() {
           <View className="flex-row items-center gap-3">
             <Ionicons name="person-outline" size={20} color={theme.tint} />
             <Text className="text-base font-medium text-foreground">Edit Profile</Text>
+          </View>
+          <Ionicons name="chevron-forward" size={16} color={theme.mutedText} />
+        </Pressable>
+
+        <Pressable
+          className="flex-row items-center justify-between rounded-2xl border border-border bg-card px-4 py-3.5"
+          onPress={() => setDeleteAccountOpen(true)}
+          accessibilityRole="button"
+          accessibilityLabel="Delete account"
+        >
+          <View className="flex-row items-center gap-3">
+            <Ionicons name="trash-outline" size={20} color="#dc2626" />
+            <Text className="text-base font-medium text-destructive">Delete Account</Text>
           </View>
           <Ionicons name="chevron-forward" size={16} color={theme.mutedText} />
         </Pressable>
@@ -102,6 +146,66 @@ export default function SettingsScreen() {
             onSaved={() => setInterestsOpen(false)}
           />
         </BottomSheetScrollView>
+      </DrawerModal>
+
+      <DrawerModal
+        open={deleteAccountOpen}
+        onClose={() => {
+          if (isDeletingAccount) return;
+          setDeleteAccountOpen(false);
+          setDeleteConfirmation('');
+        }}
+        snapPoints={['55%']}
+        enablePanDownToClose={!isDeletingAccount}
+        backdropAppearsOnIndex={0}
+        backdropDisappearsOnIndex={-1}
+        keyboardBehavior="interactive"
+      >
+        <View className="px-6 pb-8 pt-2">
+          <Text className="text-[17px] font-bold text-foreground">Delete account</Text>
+          <Text className="mt-2 text-sm leading-6 text-muted-foreground">
+            This permanently deletes your Fomo account. Your posts and comments will remain visible
+            as <Text className="font-semibold text-foreground">Deleted account</Text>. To confirm,
+            type{' '}
+            <Text className="font-semibold text-foreground">{DELETE_ACCOUNT_CONFIRMATION}</Text>{' '}
+            below.
+          </Text>
+
+          <View className="mt-5">
+            <AuthInput
+              label="Confirmation"
+              value={deleteConfirmation}
+              onChangeText={setDeleteConfirmation}
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!isDeletingAccount}
+              placeholder={DELETE_ACCOUNT_CONFIRMATION}
+            />
+          </View>
+
+          <View className="mt-6 gap-3">
+            <Button
+              variant="destructive"
+              disabled={!canDeleteAccount || isDeletingAccount}
+              onPress={() => void handleDeleteAccount()}
+            >
+              <ButtonText variant="destructive">
+                {isDeletingAccount ? 'Deleting account...' : 'Delete account permanently'}
+              </ButtonText>
+            </Button>
+
+            <Button
+              variant="secondary"
+              disabled={isDeletingAccount}
+              onPress={() => {
+                setDeleteAccountOpen(false);
+                setDeleteConfirmation('');
+              }}
+            >
+              <ButtonText variant="secondary">Cancel</ButtonText>
+            </Button>
+          </View>
+        </View>
       </DrawerModal>
     </>
   );

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -31,6 +31,7 @@ import type * as seed from "../seed.js";
 import type * as support from "../support.js";
 import type * as tags from "../tags.js";
 import type * as temp_seed from "../temp_seed.js";
+import type * as user_identity from "../user_identity.js";
 import type * as users from "../users.js";
 
 import type {
@@ -63,6 +64,7 @@ declare const fullApi: ApiFromModules<{
   support: typeof support;
   tags: typeof tags;
   temp_seed: typeof temp_seed;
+  user_identity: typeof user_identity;
   users: typeof users;
 }>;
 

--- a/packages/backend/convex/comments.ts
+++ b/packages/backend/convex/comments.ts
@@ -6,6 +6,7 @@ import {
   __backend_only_getAndAuthenticateCurrentConvexUser,
   __backend_only_guestOrAuthenticatedUser,
 } from './auth';
+import { getAvatarUrlForUser, getDisplayNameForUser } from './user_identity';
 
 export type SerializedComment = {
   id: Id<'comments'>;
@@ -104,8 +105,8 @@ export async function getThreadedCommentsByPost(ctx: QueryCtx, postId: Doc<'post
       return {
         id: comment._id,
         text: comment.text,
-        authorName: commentAuthor?.displayName || commentAuthor?.username || 'Unknown user',
-        authorAvatarUrl: commentAuthor?.avatarUrl || '',
+        authorName: getDisplayNameForUser(commentAuthor),
+        authorAvatarUrl: getAvatarUrlForUser(commentAuthor),
         creationTime: comment._creationTime,
         likes: comment.likeCount ?? 0,
         liked: likedCommentIds.has(comment._id),

--- a/packages/backend/convex/events/queries.ts
+++ b/packages/backend/convex/events/queries.ts
@@ -5,6 +5,7 @@ import type { Doc } from '../_generated/dataModel';
 import { query, type QueryCtx } from '../_generated/server';
 import { __backend_only_guestOrAuthenticatedUser } from '../auth';
 import { getThreadedCommentsByPost } from '../comments';
+import { getAvatarUrlForUser, getDisplayNameForUser, getUsernameForUser } from '../user_identity';
 import { getAttendeeCount } from './attendance';
 
 export function latLngToH3Index(lat: number, lng: number, resolution: number = 9): string {
@@ -91,9 +92,9 @@ async function serializeEventFeedPost(
     id: post._id,
     caption: post.caption ?? '',
     creationTime: post._creationTime,
-    authorName: author?.displayName || author?.username || 'Unknown user',
-    authorUsername: author?.username ?? '',
-    authorAvatarUrl: author?.avatarUrl || '',
+    authorName: getDisplayNameForUser(author),
+    authorUsername: getUsernameForUser(author),
+    authorAvatarUrl: getAvatarUrlForUser(author),
     likes: post.likeCount ?? likes.length,
     liked: viewerId ? likes.some((like) => like.userId === viewerId) : false,
     mediaIds,
@@ -198,7 +199,7 @@ export const getTopMediaPosts = query({
           liked: like !== null,
           matchedTagCount: 0,
           creationTime: post._creationTime,
-          authorName: author?.displayName || author?.username || 'Unknown user',
+          authorName: getDisplayNameForUser(author),
         };
       })
     );

--- a/packages/backend/convex/posts.ts
+++ b/packages/backend/convex/posts.ts
@@ -2,6 +2,7 @@ import { v } from 'convex/values';
 
 import { mutation, query } from './_generated/server';
 import { __backend_only_getAndAuthenticateCurrentConvexUser } from './auth';
+import { getAvatarUrlForUser, getDisplayNameForUser } from './user_identity';
 
 export const createPost = mutation({
   args: {
@@ -58,8 +59,8 @@ export const getPostById = query({
 
         return {
           id: comment._id,
-          authorName: commentAuthor?.displayName || commentAuthor?.username || 'Unknown user',
-          authorAvatarUrl: commentAuthor?.avatarUrl || '',
+          authorName: getDisplayNameForUser(commentAuthor),
+          authorAvatarUrl: getAvatarUrlForUser(commentAuthor),
           text: comment.text,
         };
       })
@@ -70,8 +71,8 @@ export const getPostById = query({
       caption: post.caption ?? '',
       mediaIds,
       likeCount: post.likeCount ?? 0,
-      authorName: author?.displayName || author?.username || 'Unknown user',
-      authorAvatarUrl: author?.avatarUrl || '',
+      authorName: getDisplayNameForUser(author),
+      authorAvatarUrl: getAvatarUrlForUser(author),
       comments: commentsWithAuthors,
     };
   },

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -21,6 +21,7 @@ export default defineSchema({
     username: v.string(), // should be unique and this is the main display/handle on frontend
     displayName: v.string(), // display names that can be changed often/whenever? --- not sure if this will be a clerk value tbh
     avatarUrl: v.string(), // should get from clerk
+    deletedAt: v.optional(v.number()),
   })
     .index('by_clerkId', ['clerkId'])
     .index('by_username', ['username']),

--- a/packages/backend/convex/user_identity.ts
+++ b/packages/backend/convex/user_identity.ts
@@ -1,0 +1,33 @@
+type UserIdentity = {
+  username?: string | null;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  deletedAt?: number | null;
+};
+
+export const DELETED_ACCOUNT_DISPLAY_NAME = 'Deleted account';
+
+function hasDeletedAt(user: UserIdentity) {
+  return typeof user.deletedAt === 'number';
+}
+
+export function isDeletedAccount(user: UserIdentity | null | undefined) {
+  if (!user) return false;
+  return hasDeletedAt(user);
+}
+
+export function getDisplayNameForUser(user: UserIdentity | null | undefined) {
+  if (!user) return 'Unknown user';
+  if (isDeletedAccount(user)) return DELETED_ACCOUNT_DISPLAY_NAME;
+  return user.displayName || user.username || 'Unknown user';
+}
+
+export function getUsernameForUser(user: UserIdentity | null | undefined) {
+  if (!user || isDeletedAccount(user)) return '';
+  return user.username || '';
+}
+
+export function getAvatarUrlForUser(user: UserIdentity | null | undefined) {
+  if (!user || isDeletedAccount(user)) return '';
+  return user.avatarUrl || '';
+}

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -3,12 +3,13 @@ import { env } from '@fomo/env/backend';
 import { v, type Validator } from 'convex/values';
 
 import { Doc, Id } from './_generated/dataModel';
-import { internalMutation, mutation, query, QueryCtx } from './_generated/server';
+import { internalMutation, mutation, query, QueryCtx, type MutationCtx } from './_generated/server';
 import {
   __backend_only_getAndAuthenticateCurrentConvexUser,
   __backend_only_guestOrAuthenticatedUser,
 } from './auth';
 import { getThreadedCommentsByPost } from './comments';
+import { getAvatarUrlForUser, getDisplayNameForUser, getUsernameForUser } from './user_identity';
 
 export const BIO_MAX_LENGTH = 250;
 
@@ -111,6 +112,93 @@ function clerkIdFromClerkUserId(clerkUserId: string): string {
   return `${env.CLERK_JWT_ISSUER_DOMAIN}|${clerkUserId}`;
 }
 
+async function anonymizeDeletedUser(ctx: MutationCtx, user: Doc<'users'>) {
+  const [
+    attendance,
+    sentFriendships,
+    receivedFriendships,
+    friendRecs,
+    userTagWeights,
+    userTagPrefs,
+    eventRecs,
+    hostedEvents,
+  ] = await Promise.all([
+    ctx.db
+      .query('attendance')
+      .withIndex('by_userId', (q) => q.eq('userId', user._id))
+      .collect(),
+    ctx.db
+      .query('friends')
+      .withIndex('by_requesterId', (q) => q.eq('requesterId', user._id))
+      .collect(),
+    ctx.db
+      .query('friends')
+      .withIndex('by_recipientId', (q) => q.eq('recipientId', user._id))
+      .collect(),
+    ctx.db
+      .query('friendRecs')
+      .withIndex('by_userId', (q) => q.eq('userId', user._id))
+      .collect(),
+    ctx.db
+      .query('userTagWeights')
+      .withIndex('by_userId', (q) => q.eq('userId', user._id))
+      .collect(),
+    ctx.db
+      .query('userTagPreferences')
+      .withIndex('by_userId', (q) => q.eq('userId', user._id))
+      .collect(),
+    ctx.db
+      .query('eventRecs')
+      .withIndex('by_userId', (q) => q.eq('userId', user._id))
+      .collect(),
+    ctx.db.query('events').collect(),
+  ]);
+
+  for (const row of attendance) {
+    await ctx.db.delete(row._id);
+  }
+
+  for (const friendship of [...sentFriendships, ...receivedFriendships]) {
+    const existingFriendship = await ctx.db.get(friendship._id);
+    if (existingFriendship) {
+      await ctx.db.delete(friendship._id);
+    }
+  }
+
+  for (const rec of friendRecs) {
+    await ctx.db.delete(rec._id);
+  }
+
+  for (const row of userTagWeights) {
+    await ctx.db.delete(row._id);
+  }
+
+  for (const row of userTagPrefs) {
+    await ctx.db.delete(row._id);
+  }
+
+  for (const row of eventRecs) {
+    await ctx.db.delete(row._id);
+  }
+
+  for (const event of hostedEvents) {
+    if (!event.hostIds.includes(user._id)) {
+      continue;
+    }
+
+    await ctx.db.patch(event._id, {
+      hostIds: event.hostIds.filter((hostId: Id<'users'>) => hostId !== user._id),
+    });
+  }
+
+  await ctx.db.patch(user._id, {
+    deletedAt: Date.now(),
+    displayName: '',
+    avatarUrl: '',
+    bio: '',
+  });
+}
+
 export const upsertFromClerk = internalMutation({
   args: { data: v.any() as Validator<UserJSON> }, // no runtime validation, trust Clerk
   async handler(ctx, { data }) {
@@ -137,7 +225,10 @@ export const upsertFromClerk = internalMutation({
       return;
     }
 
-    await ctx.db.patch(existing._id, userAttributes);
+    await ctx.db.patch(existing._id, {
+      ...userAttributes,
+      deletedAt: undefined,
+    });
   },
 });
 
@@ -169,7 +260,7 @@ export const deleteFromClerk = internalMutation({
       .unique();
 
     if (existing !== null) {
-      await ctx.db.delete(existing._id);
+      await anonymizeDeletedUser(ctx, existing);
     }
   },
 });
@@ -189,7 +280,7 @@ export const getProfileById = query({
   handler: async (ctx, { userId }) => {
     const user = await ctx.db.get(userId);
 
-    if (!user) {
+    if (!user || user.deletedAt != null) {
       return null;
     }
 
@@ -207,7 +298,7 @@ export const getProfileByUsername = query({
       .withIndex('by_username', (q) => q.eq('username', username))
       .first();
 
-    if (!user) {
+    if (!user || user.deletedAt != null) {
       return null;
     }
 
@@ -238,9 +329,9 @@ async function serializeProfileFeedPost(
     id: post._id,
     caption: post.caption ?? '',
     creationTime: post._creationTime,
-    authorName: author?.displayName || author?.username || 'Unknown user',
-    authorUsername: author?.username ?? '',
-    authorAvatarUrl: author?.avatarUrl || '',
+    authorName: getDisplayNameForUser(author),
+    authorUsername: getUsernameForUser(author),
+    authorAvatarUrl: getAvatarUrlForUser(author),
     likes: post.likeCount ?? likes.length,
     liked: viewerId ? likes.some((like) => like.userId === viewerId) : false,
     mediaIds: post.mediaIds ?? [],


### PR DESCRIPTION
## Summary

Adds an in-app account deletion flow to the mobile settings screen with a typed confirmation step. It also updates backend user deletion handling so deleted accounts are tombstoned with deletedAt, removed from active profile surfaces, and still shown as Deleted account on existing posts and comments.

---

## Why is this change necessary?

App Review rejected the app because users could create accounts but could not initiate account deletion from within the app. This change adds a compliant deletion flow directly in the mobile app and preserves existing user-generated content without leaving deleted accounts accessible as normal profiles.

---

## Changes

- Added a Delete Account entry to the mobile settings screen
- Added a confirmation sheet that requires typing Delete account before deletion
- Wired the mobile flow to Clerk account deletion via user.delete()
- Redirects the user out of the app session after deletion
- Added deletedAt tombstone support to the backend users schema
- Added shared backend helpers for rendering deleted users as Deleted account
- Updated backend webhook deletion handling to tombstone users instead of hard-deleting authored content
- Removed deleted users from direct profile lookups while preserving their posts and comments
- Updated post/comment/event serializers to hide deleted usernames/avatars and show Deleted account instead