### PR TITLE
Fix Random Crash on Settings

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile/settings/connected-accounts.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/settings/connected-accounts.tsx
@@ -9,11 +9,11 @@ function ProviderIcon({ provider }: { provider: string }) {
   const theme = useAppTheme();
 
   if (provider.includes('apple')) {
-    return <Ionicons name="logo-apple" size={20} color={theme.primaryText} />;
+    return <Ionicons name="logo-apple" size={26} color={theme.text} />;
   }
 
   if (provider.includes('google')) {
-    return <Image source={googleGLogo} style={{ width: 20, height: 20 }} resizeMode="contain" />;
+    return <Image source={googleGLogo} style={{ width: 26, height: 26 }} resizeMode="contain" />;
   }
 
   return <Ionicons name="link-outline" size={18} color={theme.tint} />;

--- a/apps/mobile/src/app/(tabs)/profile/settings/index.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/settings/index.tsx
@@ -11,11 +11,14 @@ import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useQuery } from 'convex/react';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Alert, Image, ScrollView, Text, View } from 'react-native';
 
 const TERMS_URL = 'https://fomo-app.dev/terms';
 const PRIVACY_URL = 'https://fomo-app.dev/privacy';
+const DRAWER_INTERACTION_LOCK_MS = 300;
+
+type SettingsDrawer = 'appearance' | 'interests' | 'delete-account' | null;
 
 export default function SettingsScreen() {
   const clerk = useClerk();
@@ -23,15 +26,38 @@ export default function SettingsScreen() {
   const router = useRouter();
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
-  const [deleteAccountOpen, setDeleteAccountOpen] = useState(false);
-  const [interestsOpen, setInterestsOpen] = useState(false);
-  const [appearanceOpen, setAppearanceOpen] = useState(false);
+  const [activeDrawer, setActiveDrawer] = useState<SettingsDrawer>(null);
+  const [isInteractionLocked, setIsInteractionLocked] = useState(false);
 
   const blockedUsers = useQuery(api.moderation.block.getBlockedUsers, {});
   const blockedCount = blockedUsers?.length;
 
   const initials =
     [user?.firstName?.[0], user?.lastName?.[0]].filter(Boolean).join('').toUpperCase() || '?';
+  const isDrawerOpen = activeDrawer !== null;
+
+  useEffect(() => {
+    if (!isInteractionLocked) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setIsInteractionLocked(false);
+    }, DRAWER_INTERACTION_LOCK_MS);
+
+    return () => clearTimeout(timeout);
+  }, [isInteractionLocked]);
+
+  function openDrawer(nextDrawer: Exclude<SettingsDrawer, null>) {
+    if (isInteractionLocked) return;
+    setIsInteractionLocked(true);
+    setActiveDrawer(nextDrawer);
+  }
+
+  function closeDrawer() {
+    setIsInteractionLocked(true);
+    setActiveDrawer(null);
+  }
 
   function confirmLogout() {
     Alert.alert('Log out', 'Are you sure you want to log out?', [
@@ -57,7 +83,7 @@ export default function SettingsScreen() {
 
     try {
       await user.delete();
-      setDeleteAccountOpen(false);
+      closeDrawer();
       await signOutClerkExpo(clerk);
       Alert.alert('Account deleted', 'Your account has been permanently deleted.');
     } catch (error) {
@@ -76,6 +102,8 @@ export default function SettingsScreen() {
         className="flex-1 bg-background"
         contentInsetAdjustmentBehavior="automatic"
         contentContainerClassName="grow p-6 gap-6"
+        pointerEvents={isDrawerOpen || isInteractionLocked ? 'none' : 'auto'}
+        scrollEnabled={!isDrawerOpen && !isInteractionLocked}
       >
         {/* Profile summary */}
         <View className="items-center gap-3 pb-2">
@@ -98,12 +126,12 @@ export default function SettingsScreen() {
             <SettingsRow
               icon="color-palette-outline"
               label="Appearance"
-              onPress={() => setAppearanceOpen(true)}
+              onPress={() => openDrawer('appearance')}
             />
             <SettingsRow
               icon="pizza"
               label="Interests"
-              onPress={() => setInterestsOpen(true)}
+              onPress={() => openDrawer('interests')}
               isLast
             />
           </View>
@@ -126,7 +154,7 @@ export default function SettingsScreen() {
             <SettingsRow
               icon="trash-outline"
               label="Delete Account"
-              onPress={() => setDeleteAccountOpen(true)}
+              onPress={() => openDrawer('delete-account')}
               destructive
               isLast
             />
@@ -183,10 +211,10 @@ export default function SettingsScreen() {
         </View>
       </ScrollView>
 
-      {appearanceOpen ? (
+      {activeDrawer === 'appearance' ? (
         <DrawerModal
           open
-          onClose={() => setAppearanceOpen(false)}
+          onClose={closeDrawer}
           snapPoints={['28%']}
           enablePanDownToClose
           backdropAppearsOnIndex={0}
@@ -199,10 +227,10 @@ export default function SettingsScreen() {
         </DrawerModal>
       ) : null}
 
-      {interestsOpen ? (
+      {activeDrawer === 'interests' ? (
         <DrawerModal
           open
-          onClose={() => setInterestsOpen(false)}
+          onClose={closeDrawer}
           snapPoints={['48%']}
           enablePanDownToClose
           backdropAppearsOnIndex={0}
@@ -222,17 +250,17 @@ export default function SettingsScreen() {
               saveLabel="Save interests"
               savingLabel="Saving..."
               successMessage="Your interests have been updated."
-              onSaved={() => setInterestsOpen(false)}
+              onSaved={closeDrawer}
             />
           </BottomSheetScrollView>
         </DrawerModal>
       ) : null}
 
-      {deleteAccountOpen ? (
+      {activeDrawer === 'delete-account' ? (
         <DeleteAccountDrawer
           open
           isDeletingAccount={isDeletingAccount}
-          onClose={() => setDeleteAccountOpen(false)}
+          onClose={closeDrawer}
           onDeleteAccount={() => void handleDeleteAccount()}
         />
       ) : null}

--- a/apps/mobile/src/app/(tabs)/profile/settings/index.tsx
+++ b/apps/mobile/src/app/(tabs)/profile/settings/index.tsx
@@ -183,53 +183,59 @@ export default function SettingsScreen() {
         </View>
       </ScrollView>
 
-      <DrawerModal
-        open={appearanceOpen}
-        onClose={() => setAppearanceOpen(false)}
-        snapPoints={['28%']}
-        enablePanDownToClose
-        backdropAppearsOnIndex={0}
-        backdropDisappearsOnIndex={-1}
-      >
-        <View className="px-6 pb-6 pt-2">
-          <Text className="mb-4 text-[17px] font-bold text-foreground">Appearance</Text>
-          <ThemePicker />
-        </View>
-      </DrawerModal>
+      {appearanceOpen ? (
+        <DrawerModal
+          open
+          onClose={() => setAppearanceOpen(false)}
+          snapPoints={['28%']}
+          enablePanDownToClose
+          backdropAppearsOnIndex={0}
+          backdropDisappearsOnIndex={-1}
+        >
+          <View className="px-6 pb-6 pt-2">
+            <Text className="mb-4 text-[17px] font-bold text-foreground">Appearance</Text>
+            <ThemePicker />
+          </View>
+        </DrawerModal>
+      ) : null}
 
-      <DrawerModal
-        open={interestsOpen}
-        onClose={() => setInterestsOpen(false)}
-        snapPoints={['48%']}
-        enablePanDownToClose
-        backdropAppearsOnIndex={0}
-        backdropDisappearsOnIndex={-1}
-      >
-        <View className="mx-6 mb-4">
-          <Text className="text-[17px] font-bold text-foreground">Interests</Text>
-          <Text className="mt-1 text-sm text-muted-foreground">
-            Update the tags that describe what you want to see more of.
-          </Text>
-        </View>
-        <BottomSheetScrollView keyboardShouldPersistTaps="handled">
-          <InterestsPicker
-            variant="sheet"
-            title="Interests"
-            subtitle=""
-            saveLabel="Save interests"
-            savingLabel="Saving..."
-            successMessage="Your interests have been updated."
-            onSaved={() => setInterestsOpen(false)}
-          />
-        </BottomSheetScrollView>
-      </DrawerModal>
+      {interestsOpen ? (
+        <DrawerModal
+          open
+          onClose={() => setInterestsOpen(false)}
+          snapPoints={['48%']}
+          enablePanDownToClose
+          backdropAppearsOnIndex={0}
+          backdropDisappearsOnIndex={-1}
+        >
+          <View className="mx-6 mb-4">
+            <Text className="text-[17px] font-bold text-foreground">Interests</Text>
+            <Text className="mt-1 text-sm text-muted-foreground">
+              Update the tags that describe what you want to see more of.
+            </Text>
+          </View>
+          <BottomSheetScrollView keyboardShouldPersistTaps="handled">
+            <InterestsPicker
+              variant="sheet"
+              title="Interests"
+              subtitle=""
+              saveLabel="Save interests"
+              savingLabel="Saving..."
+              successMessage="Your interests have been updated."
+              onSaved={() => setInterestsOpen(false)}
+            />
+          </BottomSheetScrollView>
+        </DrawerModal>
+      ) : null}
 
-      <DeleteAccountDrawer
-        open={deleteAccountOpen}
-        isDeletingAccount={isDeletingAccount}
-        onClose={() => setDeleteAccountOpen(false)}
-        onDeleteAccount={() => void handleDeleteAccount()}
-      />
+      {deleteAccountOpen ? (
+        <DeleteAccountDrawer
+          open
+          isDeletingAccount={isDeletingAccount}
+          onClose={() => setDeleteAccountOpen(false)}
+          onDeleteAccount={() => void handleDeleteAccount()}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/mobile/src/features/create/components/camera/view.tsx
+++ b/apps/mobile/src/features/create/components/camera/view.tsx
@@ -4,7 +4,6 @@ import { LatestGalleryImage } from '@/features/create/components/latest-gallery-
 import { useCapture } from '@/features/create/hooks/use-capture';
 import type { CreateMode } from '@/features/create/types';
 import { Ionicons } from '@expo/vector-icons';
-import { useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -63,15 +62,15 @@ export function CreateCameraCaptureView({
     }
   }, [refreshCameraPermission]);
 
-  useFocusEffect(
-    useCallback(() => {
-      refreshCameraPermission();
+  useEffect(() => {
+    refreshCameraPermission();
 
-      if (Camera.getCameraPermissionStatus() === 'not-determined') {
-        void requestCameraAccess();
-      }
-    }, [refreshCameraPermission, requestCameraAccess])
-  );
+    if (!isActive || Camera.getCameraPermissionStatus() !== 'not-determined') {
+      return;
+    }
+
+    void requestCameraAccess();
+  }, [isActive, refreshCameraPermission, requestCameraAccess]);
 
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {


### PR DESCRIPTION
fixed the random crash, i even reverted to old builds that had the crash and they weren't crashing anymore. i hate.

## Summary

This PR fixes a couple of mobile UX/runtime issues by making Settings drawers render more safely and tightening when camera permissions are requested. It also includes a small visual polish update for connected account provider icons.

---

## Why is this change necessary?

The current mobile behavior can trigger unstable drawer interactions in Settings and request camera access too aggressively. This change is necessary to prevent drawer-related crashes, avoid unnecessary permission prompts until the camera view is actually active, and clean up a small inconsistency in connected account icon presentation.

---

## Changes

- Reworked mobile Settings drawer state to use a single active drawer instead of multiple simultaneously mounted drawer states.
- Conditionally render Settings drawers only when active to avoid overlapping drawer behavior and reduce crash risk.
- Added a short interaction lock and disabled background scrolling/taps while drawer transitions are happening.
- Updated delete account and interests flows to use the shared drawer open/close behavior.
- Changed camera permission handling to refresh on active view state and only request permission when the camera screen is active and permission is still not-determined.
- Removed the previous focus-effect-based permission request flow in favor of a simpler useEffect tied to screen activity.
- Increased Apple and Google connected account icon sizes and aligned Apple icon color usage with the current theme text color.