### PR TITLE
DB migration

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -26,9 +26,11 @@ import type * as files from "../files.js";
 import type * as friends from "../friends.js";
 import type * as http from "../http.js";
 import type * as likes from "../likes.js";
+import type * as migrations from "../migrations.js";
 import type * as moderation_block from "../moderation/block.js";
 import type * as moderation_report from "../moderation/report.js";
 import type * as posts from "../posts.js";
+import type * as runMigrations from "../runMigrations.js";
 import type * as seed from "../seed.js";
 import type * as support from "../support.js";
 import type * as tags from "../tags.js";
@@ -61,9 +63,11 @@ declare const fullApi: ApiFromModules<{
   friends: typeof friends;
   http: typeof http;
   likes: typeof likes;
+  migrations: typeof migrations;
   "moderation/block": typeof moderation_block;
   "moderation/report": typeof moderation_report;
   posts: typeof posts;
+  runMigrations: typeof runMigrations;
   seed: typeof seed;
   support: typeof support;
   tags: typeof tags;
@@ -98,4 +102,92 @@ export declare const internal: FilterApi<
   FunctionReference<any, "internal">
 >;
 
-export declare const components: {};
+export declare const components: {
+  migrations: {
+    lib: {
+      cancel: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+      cancelAll: FunctionReference<
+        "mutation",
+        "internal",
+        { sinceTs?: number },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        null
+      >;
+      getStatus: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; names?: Array<string> },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      migrate: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          dryRun: boolean;
+          fnHandle: string;
+          name: string;
+          next?: Array<{ fnHandle: string; name: string }>;
+          oneBatchOnly?: boolean;
+          reset?: boolean;
+        },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+    };
+  };
+};

--- a/packages/backend/convex/convex.config.ts
+++ b/packages/backend/convex/convex.config.ts
@@ -1,0 +1,7 @@
+import migrations from '@convex-dev/migrations/convex.config.js';
+import { defineApp } from 'convex/server';
+
+const app = defineApp();
+app.use(migrations);
+
+export default app;

--- a/packages/backend/convex/migrations.ts
+++ b/packages/backend/convex/migrations.ts
@@ -1,0 +1,15 @@
+import { Migrations } from '@convex-dev/migrations';
+import { components } from './_generated/api.js';
+import { DataModel } from './_generated/dataModel.js';
+
+export const migrations = new Migrations<DataModel>(components.migrations);
+export const run = migrations.runner();
+
+export const setDefaultUpdatedAt = migrations.define({
+  table: 'attendance',
+  migrateOne: async (ctx, doc) => {
+    if (doc.updatedAt === undefined) {
+      await ctx.db.patch(doc._id, { updatedAt: Date.now() });
+    }
+  },
+});

--- a/packages/backend/convex/runMigrations.ts
+++ b/packages/backend/convex/runMigrations.ts
@@ -1,0 +1,4 @@
+import { internal } from './_generated/api.js';
+import { migrations } from './migrations.js';
+
+export const runSetDefaultUpdatedAt = migrations.runner(internal.migrations.setDefaultUpdatedAt);

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -68,7 +68,7 @@ export default defineSchema({
       v.union(v.literal('going'), v.literal('interested'), v.literal('uninterested'))
     ),
     notification: v.optional(v.union(v.literal('all'), v.literal('friends'), v.literal('none'))),
-    updatedAt: v.number(),
+    updatedAt: v.number(), // IMPORTANT: if field is missing, set it to optional, run "npx convex run runMigrations:runSetDefaultUpdatedAt", then remove optional.
     previousStatus: v.optional(
       v.union(v.literal('going'), v.literal('interested'), v.literal('uninterested'))
     ),

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@clerk/backend": "^3.4.1",
+    "@convex-dev/migrations": "^0.3.4",
     "@fomo/env": "workspace:*",
     "convex": "^1.32.0",
     "h3-js": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       '@clerk/backend':
         specifier: ^3.4.1
         version: 3.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@convex-dev/migrations':
+        specifier: ^0.3.4
+        version: 0.3.4(convex@1.34.1(@clerk/clerk-react@5.61.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
       '@fomo/env':
         specifier: workspace:*
         version: link:../env
@@ -1460,6 +1463,14 @@ packages:
         integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==,
       }
     engines: { node: '>=v18' }
+
+  '@convex-dev/migrations@0.3.4':
+    resolution:
+      {
+        integrity: sha512-fCUkc4hDzkZTgxicjV1WN4QfUdDDPPrMtvC7VgSLTGssg1B8pm+XlPC6NbZ2Aes38Xf5iiodX+y8VnU96narKQ==,
+      }
+    peerDependencies:
+      convex: ^1.24.8
 
   '@edge-runtime/primitives@6.0.0':
     resolution:
@@ -13349,6 +13360,10 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
 
+  '@convex-dev/migrations@0.3.4(convex@1.34.1(@clerk/clerk-react@5.61.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      convex: 1.34.1(@clerk/clerk-react@5.61.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+
   '@edge-runtime/primitives@6.0.0': {}
 
   '@edge-runtime/vm@5.0.0':
@@ -15111,7 +15126,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.3(bufferutil@4.1.0)
-      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.83.3(bufferutil@4.1.0)
       metro-core: 0.83.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -18836,6 +18851,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-config@0.83.3(bufferutil@4.1.0):
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.3(bufferutil@4.1.0)
+      metro-cache: 0.83.3
+      metro-core: 0.83.3
+      metro-runtime: 0.83.3
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-config@0.83.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -18988,7 +19018,7 @@ snapshots:
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.83.3(bufferutil@4.1.0)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-resolver: 0.83.3


### PR DESCRIPTION
<!--
Before submitting this PR:
- Add appropriate labels (feature, bug, refactor, chore, docs, etc.)
- Link any related issues
- Ensure tests/build pass
-->

## Summary

Adds migration for `updatedAt` in the `attendance` table and introduces a Convex migration infrastructure to backfill existing records. 

---

## Why is this change necessary?

`attendance` records had no migration for the newly added field. Without migration, we would need to clear the whole table.

---

## Changes

- `convex/migrations.ts`: migration infrastructure setup + `setDefaultUpdatedAt` migration that backfills existing records with `Date.now()`
- `convex/runMigrations.ts`: dedicated runner for `setDefaultUpdatedAt`

---

## Testing

Step-by-step instructions for reviewers to verify the changes.

1. If the `updatedAt` row does not exist in your `attendance` table, set `updatedAt: v.optional(v.number())` in `schema.ts`
2.Deploy the branch: `npx convex dev`
3. Run the migration: `npx convex run runMigrations:runSetDefaultUpdatedAt`
4. Verify in the Convex dashboard that all attendance documents now have updatedAt populated
5. If the `updatedAt` row did not exist,  set it back to  `updatedAt: v.number()` in `schema.ts`

---

# Notes / Acknowledgements

If deploying to an environment where `attendance` records already exist and `updatedAt` is missing, the schema temporarily needs `v.optional(v.number())` before deploying. Then run the migration. After that, revert to `v.number()` and redeploy. See inline comment in `schema.ts`.

It seems like Convex has no way to support this to be fully automated; it requires that we have the manual addition and removal of optional.
