### PR TITLE
More Efficient FriendRec/EventRec

### DIFF
--- a/packages/backend/convex/data_ml/eventRec.ts
+++ b/packages/backend/convex/data_ml/eventRec.ts
@@ -91,7 +91,10 @@ export const upsertUserTagWeightsBatch = internalMutation({
   },
   handler: async (ctx, { rows }) => {
     await Promise.all(
-      rows.map(({ userId, weights }) => upsertUserTagWeightsRow(ctx, userId, weights))
+      rows.map(async ({ userId, weights }) => {
+        await upsertUserTagWeightsRow(ctx, userId, weights);
+        await ctx.db.patch(userId, { eventRecNeedsUpdate: true });
+      })
     );
   },
 });
@@ -170,6 +173,8 @@ export const upsertEventRecsBatch = internalMutation({
         } else {
           await ctx.db.insert('eventRecs', { userId, eventIds });
         }
+
+        await ctx.db.patch(userId, { eventRecNeedsUpdate: false });
       })
     );
   },
@@ -269,6 +274,13 @@ export const getUsersWithRecentActivity = internalMutation({
     );
 
     return results.filter((r): r is NonNullable<typeof r> => r !== null);
+  },
+});
+
+export const getUsersNeedingEventRec = internalQuery({
+  handler: async (ctx) => {
+    const users = await ctx.db.query('users').collect();
+    return users.filter((u) => u.eventRecNeedsUpdate === true).map((u) => u._id);
   },
 });
 

--- a/packages/backend/convex/data_ml/friendRecs.ts
+++ b/packages/backend/convex/data_ml/friendRecs.ts
@@ -3,7 +3,14 @@
 // -------------------------------------------------------
 
 import { v } from 'convex/values';
-import { internalMutation } from '../_generated/server';
+import { internalMutation, internalQuery } from '../_generated/server';
+
+export const getUsersNeedingFriendRec = internalQuery({
+  handler: async (ctx) => {
+    const users = await ctx.db.query('users').collect();
+    return users.filter((u) => u.friendRecNeedsUpdate === true).map((u) => u._id);
+  },
+});
 
 // If target user already has a row in "friendRecs", update the row.
 // If target doesn't exist in "friendRecs", add the row.
@@ -34,5 +41,7 @@ export const upsert = internalMutation({
         updatedAt: Date.now(),
       });
     }
+
+    await ctx.db.patch(args.userId, { friendRecNeedsUpdate: false });
   },
 });

--- a/packages/backend/convex/data_ml/http.ts
+++ b/packages/backend/convex/data_ml/http.ts
@@ -269,4 +269,28 @@ export function registerDataMlRoutes(http: HttpRouter) {
       return new Response(JSON.stringify(result), { status: 200 });
     }),
   });
+
+  http.route({
+    path: '/data-ml/get-users-needing-event-rec',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
+
+      const result = await ctx.runQuery(internal.data_ml.eventRec.getUsersNeedingEventRec);
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
+
+  http.route({
+    path: '/data-ml/get-users-needing-friend-rec',
+    method: 'GET',
+    handler: httpAction(async (ctx, req) => {
+      const authError = validateSecret(req);
+      if (authError) return authError;
+
+      const result = await ctx.runQuery(internal.data_ml.friendRecs.getUsersNeedingFriendRec);
+      return new Response(JSON.stringify(result), { status: 200 });
+    }),
+  });
 }

--- a/packages/backend/convex/events/attendance.ts
+++ b/packages/backend/convex/events/attendance.ts
@@ -114,6 +114,7 @@ export const setViewerAttendance = mutation({
     if (attendance === null) {
       if (existingAttendance) {
         await ctx.db.delete(existingAttendance._id);
+        await ctx.db.patch(user._id, { friendRecNeedsUpdate: true });
       }
 
       return { attendance: null, notification };
@@ -134,6 +135,8 @@ export const setViewerAttendance = mutation({
         updatedAt: Date.now(),
       });
     }
+
+    await ctx.db.patch(user._id, { friendRecNeedsUpdate: true });
 
     return { attendance, notification };
   },

--- a/packages/backend/convex/events/mutations.ts
+++ b/packages/backend/convex/events/mutations.ts
@@ -28,6 +28,11 @@ export const createEvent = mutation({
       ...(mediaId !== undefined && { mediaId }),
     });
     await Promise.all(tagIds.map((tagId) => ctx.db.insert('eventTags', { eventId, tagId })));
+
+    // New event changes the pool for all users' recommendations
+    const allUsers = await ctx.db.query('users').collect();
+    await Promise.all(allUsers.map((u) => ctx.db.patch(u._id, { eventRecNeedsUpdate: true })));
+
     return eventId;
   },
 });

--- a/packages/backend/convex/posts.ts
+++ b/packages/backend/convex/posts.ts
@@ -21,6 +21,7 @@ export const createPost = mutation({
       eventId,
     });
     await Promise.all(tagIds.map((tagId) => ctx.db.insert('postTags', { postId, tagId })));
+    await ctx.db.patch(user._id, { friendRecNeedsUpdate: true });
     return postId;
   },
 });

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -22,6 +22,8 @@ export default defineSchema({
     username: v.string(), // should be unique and this is the main display/handle on frontend
     avatarUrl: v.string(), // should get from clerk
     deletedAt: v.optional(v.number()),
+    eventRecNeedsUpdate: v.optional(v.boolean()),
+    friendRecNeedsUpdate: v.optional(v.boolean()),
   })
     .index('by_clerkId', ['clerkId'])
     .index('by_username', ['username']),

--- a/packages/backend/convex/tags.ts
+++ b/packages/backend/convex/tags.ts
@@ -71,9 +71,11 @@ export const saveCurrentUserTagPreferences = mutation({
         tags: selectedTagIds,
         updatedAt: Date.now(),
       });
+      await ctx.db.patch(user._id, { eventRecNeedsUpdate: true });
       return existing._id;
     }
 
+    await ctx.db.patch(user._id, { eventRecNeedsUpdate: true });
     return await ctx.db.insert('userTagPreferences', {
       userId: user._id,
       tags: selectedTagIds,

--- a/packages/data_ml/event_rec/recommendEvent.py
+++ b/packages/data_ml/event_rec/recommendEvent.py
@@ -114,12 +114,18 @@ def get_event_features(num_tags: int, tag_id_to_idx: dict[str, int]) -> tuple[li
 
 
 def main(users: list[str], update_db: bool, model_path : str, k: int = 10) -> None:
-    # Preprocessing
-    num_tags, tag_id_to_idx = queries.get_tag_info()
+    if len(users) == 1:
+        if users[0] == "ALL":
+            all_users = queries.query_all("users")
+            users = [row["_id"] for row in all_users]
+        elif users[0] == "DIRTY":
+            users = queries.get_users_needing_event_rec()
+            if not users:
+                log("No users need event rec update.")
+                return
 
-    if len(users) == 1 and users[0] == "ALL":
-        all_users = queries.query_all("users")
-        users     = [row["_id"] for row in all_users]
+    # Preprocessing — deferred until we know there's work to do
+    num_tags, tag_id_to_idx = queries.get_tag_info()
 
     user_features          = get_user_features(users, num_tags).to(DEVICE)
     event_ids, event_array = get_event_features(num_tags, tag_id_to_idx)
@@ -199,7 +205,7 @@ def main(users: list[str], update_db: bool, model_path : str, k: int = 10) -> No
                 )
 
 
-USERS = ["ALL"]
+USERS = ["DIRTY"]
 UPDATE_DB = True
 
 if __name__ == "__main__":  # pragma: no cover

--- a/packages/data_ml/friendRec/friendRecs.py
+++ b/packages/data_ml/friendRec/friendRecs.py
@@ -64,6 +64,8 @@ def raw_matrix_postTags() -> pd.DataFrame:
     users_df = users_df[["_id"]]
 
     posts_json = queries.query_all("posts")
+    if not posts_json:
+        return pd.DataFrame()
     posts_df = pd.json_normalize(posts_json)
     posts_df = posts_df[["_id", "authorId"]]
 
@@ -73,10 +75,14 @@ def raw_matrix_postTags() -> pd.DataFrame:
 
     # Join "postTags" and "tags" dataframes
     postTags_json = queries.query_all("postTags")
+    if not postTags_json:
+        return pd.DataFrame()
     postTags_df = pd.json_normalize(postTags_json)
     postTags_df = postTags_df[["postId", "tagId"]]
 
     tags_json = queries.query_all("tags")
+    if not tags_json:
+        return pd.DataFrame()
     tags_df = pd.json_normalize(tags_json)
     tags_df = tags_df[["_id", "name"]]
 
@@ -181,6 +187,35 @@ def main_one_user(user: str, rec_amt: int) -> None:
     upsert_friend_recs(simscores_weighted, user, rec_amt)
 
 
+# Generate friend recommendations only for users flagged as needing an update.
+# Still builds full matrices so cosine similarity is computed against all users.
+def main_dirty_users(rec_amt: int) -> None:
+    dirty_user_ids = queries.get_users_needing_friend_rec()
+    if not dirty_user_ids:
+        log("No users need friend rec update.")
+        return
+
+    raw_events_df    = raw_matrix_events()
+    raw_eventTags_df = raw_matrix_eventTags()
+    raw_postTags_df  = raw_matrix_postTags()
+
+    matrix_events    = build_similarity_matrix(raw_events_df)
+    matrix_eventTags = build_similarity_matrix(raw_eventTags_df)
+    matrix_postTags  = build_similarity_matrix(raw_postTags_df)
+
+    updated = 0
+    for user_id in dirty_user_ids:
+        simscores_events_df    = get_user_scores(matrix_events, user_id)
+        simscores_eventTags_df = get_user_scores(matrix_eventTags, user_id)
+        simscores_postTags_df  = get_user_scores(matrix_postTags, user_id)
+
+        simscores_weighted = sim_scores_weighted(simscores_events_df, simscores_eventTags_df, simscores_postTags_df)
+        upsert_friend_recs(simscores_weighted, user_id, rec_amt)
+        updated += 1
+
+    log(f"Updated {updated} users in Convex with up to {rec_amt} friend recs each.")
+
+
 # Generate friend recommendations for all users.
 def main_all_users(rec_amt: int) -> None:
     user_ids = queries.get_all_user_ids()
@@ -209,6 +244,6 @@ REC_AMT  = 5         # friendRecs schema only currently supports 5.
 
 if __name__ == "__main__":
     log("Updating friend recommendations...")
-    main_all_users(REC_AMT)
+    main_dirty_users(REC_AMT)
     log("Friend recommendations updated.")
 

--- a/packages/data_ml/friendRec/friendRecs.py
+++ b/packages/data_ml/friendRec/friendRecs.py
@@ -242,7 +242,7 @@ def main_all_users(rec_amt: int) -> None:
 USER     = "n17849zzm0xksq2x2wh0gpcqs584x1q6"  # By user_id, Claude
 REC_AMT  = 5         # friendRecs schema only currently supports 5.
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     log("Updating friend recommendations...")
     main_dirty_users(REC_AMT)
     log("Friend recommendations updated.")

--- a/packages/data_ml/lib/queries.py
+++ b/packages/data_ml/lib/queries.py
@@ -160,3 +160,9 @@ def get_preferred_tags_by_user_id(user_ids: list[str]) -> list[str]:
 
 def get_all_events_after_now() -> list[dict[str, Any]]:
     return _get("/data-ml/get-all-events-after-now") # type: ignore[no-any-return]
+
+def get_users_needing_event_rec() -> list[str]:
+    return _get("/data-ml/get-users-needing-event-rec")  # type: ignore[no-any-return]
+
+def get_users_needing_friend_rec() -> list[str]:
+    return _get("/data-ml/get-users-needing-friend-rec")  # type: ignore[no-any-return]

--- a/packages/data_ml/tests/test_friendRecs.py
+++ b/packages/data_ml/tests/test_friendRecs.py
@@ -18,6 +18,7 @@ from friendRecs import (
     upsert_friend_recs,
     main_one_user,
     main_all_users,
+    main_dirty_users,
 )
 
 
@@ -470,3 +471,91 @@ def test_main_all_users_upserts_for_each_user(mock_main_all_users_dependencies: 
     assert mock_main_all_users_dependencies["upsert_friend_recs"].call_count == len(user_ids)
     called_user_ids = [call_args[0][1] for call_args in mock_main_all_users_dependencies["upsert_friend_recs"].call_args_list]
     assert called_user_ids == user_ids
+
+
+# ------------------------------
+#  main_dirty_users()
+# ------------------------------
+
+@pytest.fixture
+def mock_main_dirty_users_dependencies(
+    mock_queries: dict[str, MagicMock],
+) -> Generator[dict[str, MagicMock | list[str]], None, None]:
+    dirty_user_ids = ["u1", "u2"]
+
+    with patch("friendRecs.queries.get_users_needing_friend_rec", return_value=dirty_user_ids) as mock_get_dirty, \
+         patch("friendRecs.raw_matrix_events") as mock_raw_events, \
+         patch("friendRecs.raw_matrix_eventTags") as mock_raw_event_tags, \
+         patch("friendRecs.raw_matrix_postTags") as mock_raw_post_tags, \
+         patch("friendRecs.build_similarity_matrix") as mock_build_matrix, \
+         patch("friendRecs.get_user_scores") as mock_get_user_scores, \
+         patch("friendRecs.sim_scores_weighted") as mock_weighted, \
+         patch("friendRecs.upsert_friend_recs") as mock_upsert:
+
+        mock_raw_events.return_value = MagicMock()
+        mock_raw_event_tags.return_value = MagicMock()
+        mock_raw_post_tags.return_value = MagicMock()
+        mock_build_matrix.return_value = MagicMock()
+        mock_get_user_scores.return_value = MagicMock()
+        mock_weighted.return_value = MagicMock()
+
+        yield {
+            "dirty_user_ids":              dirty_user_ids,
+            "get_users_needing_friend_rec": mock_get_dirty,
+            "raw_matrix_events":           mock_raw_events,
+            "raw_matrix_eventTags":        mock_raw_event_tags,
+            "raw_matrix_postTags":         mock_raw_post_tags,
+            "build_similarity_matrix":     mock_build_matrix,
+            "get_user_scores":             mock_get_user_scores,
+            "sim_scores_weighted":         mock_weighted,
+            "upsert_friend_recs":          mock_upsert,
+        }
+
+
+def test_main_dirty_users_exits_early_when_no_dirty_users(
+    mock_queries: dict[str, MagicMock],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch("friendRecs.queries.get_users_needing_friend_rec", return_value=[]), \
+         patch("friendRecs.raw_matrix_events") as mock_raw_events:
+        main_dirty_users(5)
+        mock_raw_events.assert_not_called()
+    assert "No users need friend rec update." in capsys.readouterr().out
+
+
+def test_main_dirty_users_builds_raw_matrices_once(
+    mock_main_dirty_users_dependencies: dict[str, MagicMock],
+) -> None:
+    main_dirty_users(5)
+    mock_main_dirty_users_dependencies["raw_matrix_events"].assert_called_once()
+    mock_main_dirty_users_dependencies["raw_matrix_eventTags"].assert_called_once()
+    mock_main_dirty_users_dependencies["raw_matrix_postTags"].assert_called_once()
+
+
+def test_main_dirty_users_builds_similarity_matrices_once(
+    mock_main_dirty_users_dependencies: dict[str, MagicMock],
+) -> None:
+    main_dirty_users(5)
+    assert mock_main_dirty_users_dependencies["build_similarity_matrix"].call_count == 3
+
+
+def test_main_dirty_users_upserts_only_for_dirty_users(
+    mock_main_dirty_users_dependencies: dict[str, MagicMock],
+) -> None:
+    dirty_user_ids = mock_main_dirty_users_dependencies["dirty_user_ids"]
+    main_dirty_users(5)
+    assert mock_main_dirty_users_dependencies["upsert_friend_recs"].call_count == len(dirty_user_ids)
+    called_user_ids = [
+        call_args[0][1] for call_args in mock_main_dirty_users_dependencies["upsert_friend_recs"].call_args_list
+    ]
+    assert called_user_ids == dirty_user_ids
+
+
+def test_main_dirty_users_prints_updated_count(
+    mock_main_dirty_users_dependencies: dict[str, MagicMock],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dirty_user_ids = mock_main_dirty_users_dependencies["dirty_user_ids"]
+    main_dirty_users(5)
+    out = capsys.readouterr().out
+    assert f"Updated {len(dirty_user_ids)} users" in out

--- a/packages/data_ml/tests/test_queries.py
+++ b/packages/data_ml/tests/test_queries.py
@@ -463,3 +463,47 @@ def test_upsert_user_tag_weights_batch_calls_correct_path() -> None:
         mock_post.assert_called_once_with(
             "/data-ml/upsert-user-tag-weights-batch", {"rows": rows}
         )
+
+
+# ------------------------------
+#  get_users_needing_event_rec()
+# ------------------------------
+
+def test_get_users_needing_event_rec_returns_list() -> None:
+    with patch("queries._get", return_value=["u1", "u2"]):
+        result = queries.get_users_needing_event_rec()
+        assert result == ["u1", "u2"]
+
+
+def test_get_users_needing_event_rec_returns_empty_list() -> None:
+    with patch("queries._get", return_value=[]):
+        result = queries.get_users_needing_event_rec()
+        assert result == []
+
+
+def test_get_users_needing_event_rec_calls_correct_path() -> None:
+    with patch("queries._get", return_value=[]) as mock_get:
+        queries.get_users_needing_event_rec()
+        mock_get.assert_called_once_with("/data-ml/get-users-needing-event-rec")
+
+
+# ------------------------------
+#  get_users_needing_friend_rec()
+# ------------------------------
+
+def test_get_users_needing_friend_rec_returns_list() -> None:
+    with patch("queries._get", return_value=["u3", "u4"]):
+        result = queries.get_users_needing_friend_rec()
+        assert result == ["u3", "u4"]
+
+
+def test_get_users_needing_friend_rec_returns_empty_list() -> None:
+    with patch("queries._get", return_value=[]):
+        result = queries.get_users_needing_friend_rec()
+        assert result == []
+
+
+def test_get_users_needing_friend_rec_calls_correct_path() -> None:
+    with patch("queries._get", return_value=[]) as mock_get:
+        queries.get_users_needing_friend_rec()
+        mock_get.assert_called_once_with("/data-ml/get-users-needing-friend-rec")

--- a/packages/data_ml/tests/test_recommendEvent.py
+++ b/packages/data_ml/tests/test_recommendEvent.py
@@ -535,5 +535,72 @@ class TestMain:
             assert len(row["eventIds"]) == 2
 
 
+    @patch("event_rec.recommendEvent.queries.get_tag_info")
+    @patch("event_rec.recommendEvent.queries.get_users_needing_event_rec")
+    def test_main_dirty_mode_exits_early_when_no_users(
+        self,
+        mock_get_dirty: MagicMock,
+        mock_get_tag_info: MagicMock,
+    ) -> None:
+        mock_get_dirty.return_value = []
+        main(["DIRTY"], update_db=False, model_path="dummy.pt")
+        mock_get_tag_info.assert_not_called()
+
+    @patch("event_rec.recommendEvent.queries.get_users_needing_event_rec")
+    @patch("event_rec.recommendEvent.queries.get_preferred_tags_by_user_id")
+    @patch("event_rec.recommendEvent.queries.upsert_event_recs_batch")
+    @patch("event_rec.recommendEvent.queries.get_interactions_by_user_ids")
+    @patch("event_rec.recommendEvent.queries.get_by_event_ids")
+    @patch("event_rec.recommendEvent.queries.get_user_tag_weights")
+    @patch("event_rec.recommendEvent.queries.get_all_events_after_now")
+    @patch("event_rec.recommendEvent.queries.query_all")
+    @patch("event_rec.recommendEvent.queries.get_tag_info")
+    @patch("event_rec.recommendEvent.torch.load")
+    @patch("event_rec.recommendEvent.UserTower")
+    @patch("event_rec.recommendEvent.EventTower")
+    def test_main_dirty_mode_processes_flagged_users(
+        self,
+        mock_event_tower: MagicMock,
+        mock_user_tower: MagicMock,
+        mock_torch_load: MagicMock,
+        mock_get_tag_info: MagicMock,
+        mock_query_all: MagicMock,
+        mock_get_all_events: MagicMock,
+        mock_get_weights: MagicMock,
+        mock_get_by_events: MagicMock,
+        mock_get_interactions: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_preferred_tags: MagicMock,
+        mock_get_dirty: MagicMock,
+        sample_tags: List[Dict[str, Any]],
+        sample_users: List[Dict[str, Any]],
+        sample_events: List[Dict[str, Any]],
+        flat_event_tag_rows: List[Dict[str, Any]],
+        sample_interactions: Dict[str, List[Dict[str, Any]]],
+    ) -> None:
+        mock_get_dirty.return_value = ["user1"]
+        _setup_main_mocks(
+            {
+                "event_tower": mock_event_tower,
+                "user_tower": mock_user_tower,
+                "torch_load": mock_torch_load,
+                "get_tag_info": mock_get_tag_info,
+                "query_all": mock_query_all,
+                "get_all_events": mock_get_all_events,
+                "get_weights": mock_get_weights,
+                "get_by_events": mock_get_by_events,
+                "get_interactions": mock_get_interactions,
+                "get_preferred_tags": mock_get_preferred_tags,
+            },
+            sample_tags, sample_users, sample_events, flat_event_tag_rows, sample_interactions,
+        )
+        try:
+            main(["DIRTY"], update_db=False, model_path="dummy.pt")
+        except Exception as e:
+            pytest.fail(f"main() with 'DIRTY' raised {type(e).__name__} unexpectedly: {e}")
+        mock_get_dirty.assert_called_once()
+        mock_get_tag_info.assert_called_once()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!--
Before submitting this PR:
- Add appropriate labels (feature, bug, refactor, chore, docs, etc.)
- Link any related issues
- Ensure tests/build pass
-->

## Summary

Replaces the brute-force "recompute recs for all users every cron run" approach with a dirty-flag system. Two boolean fields (`eventRecNeedsUpdate`, `friendRecNeedsUpdate`) are set on users when their relevant data changes, and both recommendation scripts now only process users who actually need an update.

---

## Why is this change necessary?

The recommendation cron jobs previously recomputed results for every user on every run, regardless of whether anything had changed. For a zero-activity window this meant a full DB read + neural net inference + similarity matrix build with no benefit. The `updateUserPreferences.py` script already had an `ACTIVE` mode to mitigate this; this PR brings the same pattern to `recommendEvent.py` and `friendRecs.py`.

---

## Changes

### Schema

- Added `eventRecNeedsUpdate: optional boolean` and `friendRecNeedsUpdate: optional boolean` to the `users` table

### Convex mutations — flag setters

- `setViewerAttendance` → sets `friendRecNeedsUpdate: true` on attendance add, change, or delete
- `upsertUserTagWeightsBatch` → sets `eventRecNeedsUpdate: true` after weights are written
- `saveCurrentUserTagPreferences` → sets `eventRecNeedsUpdate: true`
- `createPost` → sets `friendRecNeedsUpdate: true`
- `createEvent` → sets `eventRecNeedsUpdate: true` on all users

### Convex mutations — flag clearers

- `upsertEventRecsBatch` → clears `eventRecNeedsUpdate: false` after writing recs
- `friendRecs.upsert` → clears `friendRecNeedsUpdate: false` after writing recs

### Convex queries + HTTP routes

- `getUsersNeedingEventRec` / `GET /data-ml/get-users-needing-event-rec`
- `getUsersNeedingFriendRec` / `GET /data-ml/get-users-needing-friend-rec`

### Python

- `lib/queries.py` — added `get_users_needing_event_rec()` and `get_users_needing_friend_rec()`
- `recommendEvent.py` — added `"DIRTY"` mode (now default); dirty check moved before `get_tag_info()` so zero-activity runs cost exactly 1 query
- `friendRecs.py` — added `main_dirty_users()` (now default entrypoint); `main_all_users()` kept for manual use
- `friendRecs.py` — fixed crash in `raw_matrix_postTags()` when `posts` or `postTags` tables are empty

---

## UML Diagram (optional)

Add a diagram if architecture, flow, or structure changed.

```mermaid
graph TD
    A[User RSVPs / posts / sets tags] --> B[Convex mutation sets flag on user]
    C[New event created] --> D[Flag set on ALL users]
    B --> E[Cron: updateUserPreferences ACTIVE]
    D --> E
    E --> F[upsertUserTagWeightsBatch\nsets eventRecNeedsUpdate]
    F --> G[Cron: recommendEvent DIRTY\nqueries flagged users only]
    G --> H[upsertEventRecsBatch\nclears eventRecNeedsUpdate]
    B --> I[Cron: friendRecs DIRTY\nqueries flagged users only]
    I --> J[upsert friendRecs\nclears friendRecNeedsUpdate]

    K[Zero activity] --> L[1 query → early exit\nno further DB or ML work]
```

## Testing

1. `npx convex dev`
2. Make sure all users are `eventRecNeedsUpdate: false` or `unset`
3. Run `python -m event_rec.recommendEvent`. Check that the logs say no users were updated.
4. Set `eventRecNeedsUpdate: true` on at least one user.
5. Run `python -m event_rec.recommendEvent`. Check that the logs say a user was updated.
6. Do the same with friend recs.
7. Feel free to use some of the existing Convex functions to see how they update the flags in the `users` table.
