### PR TITLE
Exclude blocks from friend recommendations

### DIFF
--- a/packages/data_ml/friendRec/friendRecs.py
+++ b/packages/data_ml/friendRec/friendRecs.py
@@ -2,6 +2,22 @@ import pandas as pd
 from sklearn.metrics.pairwise import cosine_similarity
 from lib import queries, log
 
+
+# Build a symmetric lookup of users who should never be recommended to each other.
+def get_blocked_user_lookup() -> dict[str, set[str]]:
+    blocked_rows = queries.query_all("blockedUsers")
+    blocked_lookup: dict[str, set[str]] = {}
+
+    for row in blocked_rows:
+        blocker_id = row["blockerId"]
+        blocked_user_id = row["blockedUserId"]
+
+        blocked_lookup.setdefault(blocker_id, set()).add(blocked_user_id)
+        blocked_lookup.setdefault(blocked_user_id, set()).add(blocker_id)
+
+    return blocked_lookup
+
+
 # Combines "attendance" and "events" into a single dataframe.
 def join_user_events() -> pd.DataFrame:
 
@@ -124,7 +140,12 @@ def sim_scores_weighted(events: pd.DataFrame, event_tags: pd.DataFrame, post_tag
 
 
 # Send recommended friends to Convex server.
-def upsert_friend_recs(sim_scores: pd.DataFrame, userId: str, rec_amt: int) -> None:
+def upsert_friend_recs(
+    sim_scores: pd.DataFrame,
+    userId: str,
+    rec_amt: int,
+    blocked_lookup: dict[str, set[str]] | None = None,
+) -> None:
 
     # For user, sort similarity scores by highest.
     sim_scores = sim_scores.dropna(subset = ["similarity_score"])
@@ -141,12 +162,14 @@ def upsert_friend_recs(sim_scores: pd.DataFrame, userId: str, rec_amt: int) -> N
     )
 
     existing_friend_ids = set(queries.get_friend_ids(userId))
+    blocked_user_ids = blocked_lookup.get(userId, set()) if blocked_lookup else set()
+    excluded_user_ids = existing_friend_ids | blocked_user_ids
 
-    # Parse out any userIds that are already friends.
+    # Parse out any userIds that are already friends or blocked in either direction.
     top_sim_scores = [
         {"userId": friendId, "score": float(score)}
         for friendId, score in top_sim_scores["similarity_score"].items()
-        if friendId not in existing_friend_ids
+        if friendId not in excluded_user_ids
     ]
 
     # If list is larger than rec_amt, truncate.
@@ -164,6 +187,8 @@ def main_one_user(user: str, rec_amt: int) -> None:
     if not queries.user_exists(user):
         raise Exception(f"\"{user}\" cannot be found in users.")
 
+    blocked_lookup = get_blocked_user_lookup()
+
     raw_events_df          = raw_matrix_events()
     raw_eventTags_df       = raw_matrix_eventTags()
     raw_postTags_df        = raw_matrix_postTags()
@@ -178,12 +203,13 @@ def main_one_user(user: str, rec_amt: int) -> None:
 
     simscores_weighted = sim_scores_weighted(simscores_events_df, simscores_eventTags_df, simscores_postTags_df)
 
-    upsert_friend_recs(simscores_weighted, user, rec_amt)
+    upsert_friend_recs(simscores_weighted, user, rec_amt, blocked_lookup)
 
 
 # Generate friend recommendations for all users.
 def main_all_users(rec_amt: int) -> None:
     user_ids = queries.get_all_user_ids()
+    blocked_lookup = get_blocked_user_lookup()
 
     # Build all raw matrices once and only generate similarity scores for each user
     raw_events_df = raw_matrix_events()
@@ -200,7 +226,7 @@ def main_all_users(rec_amt: int) -> None:
         simscores_postTags_df = get_user_scores(matrix_postTags, user_id)
 
         simscores_weighted = sim_scores_weighted(simscores_events_df, simscores_eventTags_df, simscores_postTags_df)
-        upsert_friend_recs(simscores_weighted, user_id, rec_amt)
+        upsert_friend_recs(simscores_weighted, user_id, rec_amt, blocked_lookup)
 
 
 

--- a/packages/data_ml/tests/test_friendRecs.py
+++ b/packages/data_ml/tests/test_friendRecs.py
@@ -8,6 +8,7 @@ from typing import Generator
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "friendRec"))
 from friendRecs import (
+    get_blocked_user_lookup,
     join_user_events,
     raw_matrix_events,
     raw_matrix_eventTags,
@@ -79,6 +80,10 @@ def sample_postTags() -> list[dict[str, str]]:
     ]
 
 @pytest.fixture
+def sample_blocked_users() -> list[dict[str, str]]:
+    return []
+
+@pytest.fixture
 def sample_similarity_df() -> pd.DataFrame:
     data = {
         "Hackathon": [1, 1, 0],
@@ -101,6 +106,7 @@ def mock_queries(
     sample_eventTags: list[dict[str, str]],
     sample_posts: list[dict[str, str]],
     sample_postTags: list[dict[str, str]],
+    sample_blocked_users: list[dict[str, str]],
 ) -> Generator[dict[str, MagicMock], None, None]:
     dispatch = {
         "attendance": sample_users_to_events,
@@ -110,6 +116,7 @@ def mock_queries(
         "users": sample_users,
         "posts": sample_posts,
         "postTags": sample_postTags,
+        "blockedUsers": sample_blocked_users,
     }
     with patch("friendRecs.queries.query_all", side_effect=lambda t: dispatch.get(t, [])), \
          patch("friendRecs.queries.get_friend_ids", return_value=[]) as mock_get_friend_ids, \
@@ -122,6 +129,29 @@ def mock_queries(
             "user_exists": mock_user_exists,
             "get_all_user_ids": mock_get_ids,
         }
+
+
+# ------------------------------
+#  get_blocked_user_lookup()
+# ------------------------------
+
+def test_get_blocked_user_lookup_returns_symmetric_lookup(
+    mock_queries: dict[str, MagicMock],
+) -> None:
+    with patch(
+        "friendRecs.queries.query_all",
+        return_value=[
+            {"blockerId": "u1", "blockedUserId": "u2"},
+            {"blockerId": "u3", "blockedUserId": "u1"},
+        ],
+    ):
+        blocked_lookup = get_blocked_user_lookup()
+
+    assert blocked_lookup == {
+        "u1": {"u2", "u3"},
+        "u2": {"u1"},
+        "u3": {"u1"},
+    }
 
 
 # ------------------------------
@@ -324,6 +354,25 @@ def test_upsert_friend_recs_recipient_filtering(
     rec_ids = [r["userId"] for r in recs]
     assert "u1" not in rec_ids
 
+def test_upsert_friend_recs_filters_users_blocked_by_target_user(
+    mock_queries: dict[str, MagicMock], sample_score_df: pd.DataFrame
+) -> None:
+    blocked_lookup = {"u1": {"u2"}, "u2": {"u1"}}
+    upsert_friend_recs(sample_score_df, "u1", 2, blocked_lookup)
+    _, recs = mock_queries["upsert_friend_recs"].call_args.args
+    rec_ids = [r["userId"] for r in recs]
+    assert "u2" not in rec_ids
+    assert rec_ids == ["u1"]
+
+def test_upsert_friend_recs_filters_users_who_blocked_target_user(
+    mock_queries: dict[str, MagicMock], sample_score_df: pd.DataFrame
+) -> None:
+    blocked_lookup = {"u1": {"u2"}, "u2": {"u1"}}
+    upsert_friend_recs(sample_score_df, "u1", 2, blocked_lookup)
+    _, recs = mock_queries["upsert_friend_recs"].call_args.args
+    rec_ids = [r["userId"] for r in recs]
+    assert "u2" not in rec_ids
+
 def test_upsert_friend_recs_pending_not_filtered(
     mock_queries: dict[str, MagicMock], sample_score_df: pd.DataFrame
 ) -> None:
@@ -405,6 +454,7 @@ def test_main_one_user_calls_sim_scores_weighted(mock_main_dependencies: dict[st
 def test_main_one_user_calls_upsert_friend_recs(mock_main_dependencies: dict[str, MagicMock]) -> None:
     main_one_user("alice", 5)
     mock_main_dependencies["upsert_friend_recs"].assert_called_once()
+    assert len(mock_main_dependencies["upsert_friend_recs"].call_args.args) == 4
 
 
 # ------------------------------
@@ -470,3 +520,4 @@ def test_main_all_users_upserts_for_each_user(mock_main_all_users_dependencies: 
     assert mock_main_all_users_dependencies["upsert_friend_recs"].call_count == len(user_ids)
     called_user_ids = [call_args[0][1] for call_args in mock_main_all_users_dependencies["upsert_friend_recs"].call_args_list]
     assert called_user_ids == user_ids
+    assert all(len(call_args.args) == 4 for call_args in mock_main_all_users_dependencies["upsert_friend_recs"].call_args_list)


### PR DESCRIPTION
<!--
Before submitting this PR:
- Add appropriate labels (feature, bug, refactor, chore, docs, etc.)
- Link any related issues
- Ensure tests/build pass
-->

## Summary
This PR makes friend recommendations utilize the blocked users table, and does not recommend users someone that they've blocked, or someone that has blocked them.

---

## Why is this change necessary?

Previously, we only focused on existing friends to avoid duplicate recommendations. Now that we have added blocking users, we must also make sure to not recommend anyone that has been blocked, and ensure that we only provide viable recommendations.

---

## Changes

`friendRecs.py` - added a new function `get_blocked_user_lookup` to build a lookup of users who shouldn't be recommended to each other. This is in the form of anyone the user has blocked along with anyone that has blocked the user. This is used in `upsert_friend_recs` to build a list of excluded user ids that will be dropped when providing recs for a specific user.
`test_friendRecs.py` - added tests for the new function and updated all old tests to check the new logic.

---

## Testing

Step-by-step instructions for reviewers to verify the changes.

1. Make sure to run `npx convex dev` in backend, or run `pnpm convex:dev`
2. Navigate to `packages/data_ml` and run the command `uv run  -m friendRec.friendRecs`
3. Make sure the Convex database updates friendRecs for any users who's `friendRecNeedsUpdate` value is set to true.

