### PR TITLE
Optimize File Bandwidth

### DIFF
--- a/apps/mobile/src/app/(tabs)/(map)/event/[eventId].tsx
+++ b/apps/mobile/src/app/(tabs)/(map)/event/[eventId].tsx
@@ -49,10 +49,6 @@ export default function EventPage() {
     eventId ? { eventId } : 'skip'
   );
   const setViewerAttendance = useMutation(api.events.attendance.setViewerAttendance);
-  const eventImage = useQuery(
-    api.files.getFile,
-    event?.mediaId ? { storageId: event.mediaId } : 'skip'
-  );
   const [attendance, setAttendance] = useState<AttendanceStatus>(null);
   const [notification, setNotification] = useState<NotificationPref>('all');
   const [isRsvpOpen, setIsRsvpOpen] = useState(false);
@@ -168,10 +164,10 @@ export default function EventPage() {
           <Pressable
             className="w-35 overflow-hidden rounded-2xl border border-border bg-surface-muted"
             style={rightSideHeight !== undefined ? { height: rightSideHeight } : { height: 180 }}
-            onPress={() => eventImage?.url && setHeaderCarouselOpen(true)}
-            disabled={!eventImage?.url}
+            onPress={() => event.mediaUrl != null && setHeaderCarouselOpen(true)}
+            disabled={event.mediaUrl == null}
           >
-            {eventImage?.url ? (
+            {event.mediaUrl != null ? (
               <>
                 {headerCarouselOpen && (
                   <MediaCarousel
@@ -180,7 +176,7 @@ export default function EventPage() {
                     onClose={() => setHeaderCarouselOpen(false)}
                   />
                 )}
-                <Image source={eventImage.url} className="h-full w-full" contentFit="cover" />
+                <Image source={event.mediaUrl} className="h-full w-full" contentFit="cover" />
               </>
             ) : (
               <View

--- a/apps/mobile/src/app/(tabs)/(map)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/(map)/index.tsx
@@ -144,7 +144,7 @@ export default function MapScreen() {
             id={event.id}
             coordinate={[event.location.longitude, event.location.latitude]}
             label={event.name}
-            mediaId={event.mediaId}
+            mediaUrl={event.mediaUrl}
             weight={getWeight(event.id)}
             minWeight={minWeight}
             maxWeight={maxWeight}

--- a/apps/mobile/src/features/create/components/form/event-field.tsx
+++ b/apps/mobile/src/features/create/components/form/event-field.tsx
@@ -58,7 +58,7 @@ export function EventField({ control, setValue, formActive }: EventFieldProps) {
         {selectedEvent ? (
           <View className="flex-row items-center gap-2 px-4 py-3">
             <EventSearchImage
-              mediaId={selectedEvent.mediaId}
+              mediaUrl={selectedEvent.mediaUrl}
               className="size-[18px] overflow-hidden rounded-full bg-primary/10"
             />
             <Text className="flex-1 text-[15px] text-foreground" numberOfLines={1}>
@@ -108,7 +108,7 @@ export function EventField({ control, setValue, formActive }: EventFieldProps) {
                 className={`flex-row items-center gap-3 px-4 py-3 ${index < filtered.length - 1 ? 'border-b border-muted' : ''}`}
               >
                 <EventSearchImage
-                  mediaId={event.mediaId}
+                  mediaUrl={event.mediaUrl}
                   className="size-10 overflow-hidden rounded-full bg-primary/10"
                 />
                 <View className="flex-1">

--- a/apps/mobile/src/features/events/components/top-moments/card.tsx
+++ b/apps/mobile/src/features/events/components/top-moments/card.tsx
@@ -2,9 +2,7 @@ import { Image } from '@/components/image';
 import { VideoThumbnail } from '@/components/video';
 import type { TopMediaPost } from '@/features/events/types';
 import { Ionicons } from '@expo/vector-icons';
-import { api } from '@fomo/backend/convex/_generated/api';
 import type { Id } from '@fomo/backend/convex/_generated/dataModel';
-import { useQuery } from 'convex/react';
 import { useRouter } from 'expo-router';
 import { Pressable, Text, View } from 'react-native';
 
@@ -16,8 +14,7 @@ type EventMediaTileProps = {
 
 export function EventMediaTile({ post, cell, eventId }: EventMediaTileProps) {
   const router = useRouter();
-  const thumbnailId = post.mediaIds[0]!;
-  const file = useQuery(api.files.getFile, thumbnailId ? { storageId: thumbnailId } : 'skip');
+  const file = post.thumbnailFile;
   const mediaTypeResolved = file !== undefined;
 
   return (

--- a/apps/mobile/src/features/map/components/event-marker.tsx
+++ b/apps/mobile/src/features/map/components/event-marker.tsx
@@ -1,39 +1,28 @@
 import { Image } from '@/components/image';
-import { api } from '@fomo/backend/convex/_generated/api';
-import type { Id } from '@fomo/backend/convex/_generated/dataModel';
 import MapboxGL from '@rnmapbox/maps';
-import { useQuery } from 'convex/react';
 import { Pressable, Text, View } from 'react-native';
 
 interface EventMarkerProps {
   id: string;
   coordinate: [number, number];
   label: string;
-  mediaId: Id<'_storage'> | null;
-  // Raw attendee weight — same value passed to the heatmap layer (0–6 scale).
+  mediaUrl: string | null;
   weight: number;
   minWeight: number;
   maxWeight: number;
   onPress: () => void;
 }
 
-/*
- * function provides event markers similar to life360
- * size scales with heatmap layer (one to one match)
- */
 export function EventMarker({
   id,
   coordinate,
   label,
-  mediaId,
+  mediaUrl,
   weight,
   minWeight,
   maxWeight,
   onPress,
 }: EventMarkerProps) {
-  const file = useQuery(api.files.getFile, mediaId ? { storageId: mediaId } : 'skip');
-
-  // normalize against actual min/max so the full range is always used
   const t = (weight - minWeight) / (maxWeight - minWeight || 1);
   const size = 44 + t * 44;
   const stemWidth = size * 0.28;
@@ -53,8 +42,8 @@ export function EventMarker({
             elevation: 10,
           }}
         >
-          {file?.url ? (
-            <Image source={file.url} className="h-full w-full" contentFit="cover" />
+          {mediaUrl ? (
+            <Image source={mediaUrl} className="h-full w-full" contentFit="cover" />
           ) : (
             <View className="h-full w-full items-center justify-center bg-primary/10 px-2">
               <Text className="text-lg font-bold uppercase text-foreground">

--- a/apps/mobile/src/features/map/components/search/content.tsx
+++ b/apps/mobile/src/features/map/components/search/content.tsx
@@ -195,7 +195,7 @@ export function SearchContent({
                 onSelectEvent(event.id);
               }}
             >
-              <EventSearchImage mediaId={event.mediaId} />
+              <EventSearchImage mediaUrl={event.mediaUrl} />
 
               <View className="flex-1 gap-1">
                 <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>

--- a/apps/mobile/src/features/map/components/search/event-search-image.tsx
+++ b/apps/mobile/src/features/map/components/search/event-search-image.tsx
@@ -1,24 +1,20 @@
 import { Icon } from '@/components/icon';
 import { Image } from '@/components/image';
 import { useAppTheme } from '@/lib/use-app-theme';
-import { api } from '@fomo/backend/convex/_generated/api';
-import type { Id } from '@fomo/backend/convex/_generated/dataModel';
-import { useQuery } from 'convex/react';
 import { View } from 'react-native';
 
 type EventSearchImageProps = {
-  mediaId: Id<'_storage'> | null;
+  mediaUrl: string | null;
   className?: string;
 };
 
-export function EventSearchImage({ mediaId, className }: EventSearchImageProps) {
+export function EventSearchImage({ mediaUrl, className }: EventSearchImageProps) {
   const theme = useAppTheme();
-  const file = useQuery(api.files.getFile, mediaId ? { storageId: mediaId } : 'skip');
 
   return (
     <View className={className ?? 'size-12 overflow-hidden rounded-2xl bg-primary/10'}>
-      {file?.url ? (
-        <Image source={file.url} className="h-full w-full" contentFit="cover" />
+      {mediaUrl ? (
+        <Image source={mediaUrl} className="h-full w-full" contentFit="cover" />
       ) : (
         <View className="h-full w-full items-center justify-center">
           <Icon name="place" size={22} color={theme.tint} />

--- a/apps/mobile/src/features/posts/components/feed-card/index.tsx
+++ b/apps/mobile/src/features/posts/components/feed-card/index.tsx
@@ -89,7 +89,7 @@ export function FeedCard({
           </View>
         </View>
 
-        <FeedCardMedia mediaIds={post.mediaIds} onPressMedia={setCarouselIndex} />
+        <FeedCardMedia mediaFiles={post.mediaFiles} onPressMedia={setCarouselIndex} />
 
         {post.caption ? (
           <Text className="text-[15px] leading-[21px] text-foreground">{post.caption}</Text>

--- a/apps/mobile/src/features/posts/components/feed-card/media-tile.tsx
+++ b/apps/mobile/src/features/posts/components/feed-card/media-tile.tsx
@@ -1,19 +1,17 @@
 import { Image } from '@/components/image';
 import { VideoPlayer } from '@/components/video';
-import type { FeedPost } from '@/features/posts/types';
-import { api } from '@fomo/backend/convex/_generated/api';
-import { useQuery } from 'convex/react';
 import { Pressable, Text, View } from 'react-native';
 
+type ResolvedFile = { url: string | null; isVideo: boolean } | null | undefined;
+
 type MediaTileProps = {
-  mediaId: FeedPost['mediaIds'][number] | undefined;
+  file: ResolvedFile;
   className: string;
   overlayLabel?: string;
   onPress?: () => void;
 };
 
-export function MediaTile({ mediaId, className, overlayLabel, onPress }: MediaTileProps) {
-  const file = useQuery(api.files.getFile, mediaId ? { storageId: mediaId } : 'skip');
+export function MediaTile({ file, className, overlayLabel, onPress }: MediaTileProps) {
   const mediaTypeResolved = file !== undefined;
 
   const inner = (

--- a/apps/mobile/src/features/posts/components/feed-card/media.tsx
+++ b/apps/mobile/src/features/posts/components/feed-card/media.tsx
@@ -2,25 +2,27 @@ import { MediaMosaic } from '@/components/media/media-mosaic';
 import type { FeedPost } from '@/features/posts/types';
 import { MediaTile } from './media-tile';
 
+type MediaFile = FeedPost['mediaFiles'][number];
+
 export function FeedCardMedia({
-  mediaIds,
+  mediaFiles,
   onPressMedia,
 }: {
-  mediaIds: FeedPost['mediaIds'];
+  mediaFiles: MediaFile[];
   onPressMedia: (index: number) => void;
 }) {
-  if (mediaIds.length === 0) return null;
+  if (mediaFiles.length === 0) return null;
 
-  const heightClassName = mediaIds.length <= 2 ? 'h-55' : 'h-60';
+  const heightClassName = mediaFiles.length <= 2 ? 'h-55' : 'h-60';
 
   return (
     <MediaMosaic
-      items={mediaIds}
+      items={mediaFiles}
       className={heightClassName}
-      renderItem={({ item, index, overlayLabel }) => (
+      renderItem={({ item: file, index, overlayLabel }) => (
         <MediaTile
-          mediaId={item}
-          className={mediaIds.length === 1 ? 'h-55 w-full' : 'flex-1'}
+          file={file}
+          className={mediaFiles.length === 1 ? 'h-55 w-full' : 'flex-1'}
           overlayLabel={overlayLabel}
           onPress={() => onPressMedia(index)}
         />

--- a/apps/mobile/src/features/posts/components/media-card/index.tsx
+++ b/apps/mobile/src/features/posts/components/media-card/index.tsx
@@ -121,10 +121,10 @@ export function MediaCard({
         onMomentumScrollEnd={handleScroll}
         scrollEnabled={post.mediaIds.length > 1}
       >
-        {post.mediaIds.map((mediaId, index) => (
+        {post.mediaIds.map((_, index) => (
           <MediaItem
             key={`${post.id}-${index}`}
-            mediaId={mediaId}
+            file={post.mediaFiles[index] ?? null}
             width={width}
             height={mediaHeight}
             isActive={index === activeIndex}

--- a/apps/mobile/src/features/posts/components/media-card/item.tsx
+++ b/apps/mobile/src/features/posts/components/media-card/item.tsx
@@ -1,13 +1,12 @@
 import { Image } from '@/components/image';
 import { VideoPlayer } from '@/components/video';
-import { api } from '@fomo/backend/convex/_generated/api';
-import type { Id } from '@fomo/backend/convex/_generated/dataModel';
-import { useQuery } from 'convex/react';
 import type { ImageLoadEventData } from 'expo-image';
 import { TouchableOpacity, View } from 'react-native';
 
+type ResolvedFile = { url: string | null; isVideo: boolean } | null | undefined;
+
 type MediaItemProps = {
-  mediaId: Id<'_storage'>;
+  file: ResolvedFile;
   width: number;
   height: number;
   isActive: boolean;
@@ -16,14 +15,13 @@ type MediaItemProps = {
 };
 
 export function MediaItem({
-  mediaId,
+  file,
   width,
   height,
   isActive,
   onPress,
   onNaturalSize,
 }: MediaItemProps) {
-  const file = useQuery(api.files.getFile, { storageId: mediaId });
   const mediaTypeResolved = file !== undefined;
 
   function handleImageLoad(e: ImageLoadEventData) {

--- a/apps/mobile/src/features/posts/components/media-carousel.tsx
+++ b/apps/mobile/src/features/posts/components/media-carousel.tsx
@@ -282,7 +282,7 @@ export function MediaCarousel({
                 dismissOpacity={dismissOpacity}
               />
             )}
-            keyExtractor={(item, i) => `${item}-${i}`}
+            keyExtractor={(item) => item}
           />
         </View>
 

--- a/apps/mobile/src/features/profile/components/media-grid.tsx
+++ b/apps/mobile/src/features/profile/components/media-grid.tsx
@@ -1,15 +1,12 @@
 import { Image } from '@/components/image';
 import { VideoThumbnail } from '@/components/video';
-import { api } from '@fomo/backend/convex/_generated/api';
-import type { Id } from '@fomo/backend/convex/_generated/dataModel';
 import { FlashList } from '@shopify/flash-list';
-import { useQuery } from 'convex/react';
 import { TouchableOpacity, useWindowDimensions, View } from 'react-native';
 
 export type GridMediaItem = {
   id: string;
   postId: string;
-  mediaId: Id<'_storage'>;
+  thumbnailFile: { url: string | null; isVideo: boolean } | null;
 };
 
 type MediaGridProps = {
@@ -26,7 +23,7 @@ function MediaGridItem({
   onPress: () => void;
   size: number;
 }) {
-  const file = useQuery(api.files.getFile, { storageId: item.mediaId });
+  const file = item.thumbnailFile;
   const mediaTypeResolved = file !== undefined;
 
   return (

--- a/apps/mobile/src/features/profile/profile-page.tsx
+++ b/apps/mobile/src/features/profile/profile-page.tsx
@@ -140,7 +140,7 @@ export function ProfilePage({
     .map((p) => ({
       id: p.id,
       postId: p.id,
-      mediaId: p.mediaIds[0] as Id<'_storage'>,
+      thumbnailFile: p.mediaFiles[0] ?? null,
     }));
 
   const profileBio = profile.user.bio;

--- a/packages/backend/convex/events/queries.ts
+++ b/packages/backend/convex/events/queries.ts
@@ -5,6 +5,7 @@ import type { Doc } from '../_generated/dataModel';
 import { query, type QueryCtx } from '../_generated/server';
 import { __backend_only_guestOrAuthenticatedUser } from '../auth';
 import { getThreadedCommentsByPost } from '../comments';
+import { serializeStorageFile, serializeStorageFiles } from '../files';
 import { getHiddenUserIds } from '../moderation/block';
 import { getHiddenPostIds } from '../moderation/report';
 import { getAvatarUrlForUser, getDisplayNameForUser, getUsernameForUser } from '../user_identity';
@@ -24,12 +25,13 @@ export function latLngToH3Index(lat: number, lng: number, resolution: number = 9
 }
 
 async function serializeEvent(ctx: QueryCtx, event: Doc<'events'>, recommendationScore?: number) {
-  const [attendeeCount, eventTagLinks] = await Promise.all([
+  const [attendeeCount, eventTagLinks, mediaFile] = await Promise.all([
     getAttendeeCount(ctx, event._id),
     ctx.db
       .query('eventTags')
       .withIndex('by_event', (q) => q.eq('eventId', event._id))
       .collect(),
+    event.mediaId ? serializeStorageFile(ctx, event.mediaId) : Promise.resolve(null),
   ]);
 
   const tags = await Promise.all(eventTagLinks.map(async (link) => await ctx.db.get(link.tagId)));
@@ -44,6 +46,7 @@ async function serializeEvent(ctx: QueryCtx, event: Doc<'events'>, recommendatio
     startDate: event.startDate,
     endDate: event.endDate,
     mediaId: event.mediaId ?? null,
+    mediaUrl: mediaFile?.url ?? null,
     hostIds: event.hostIds,
     recommendationScore,
   };
@@ -80,7 +83,7 @@ async function serializeEventFeedPost(
 ) {
   const mediaIds = post.mediaIds ?? [];
 
-  const [author, comments, likes, event] = await Promise.all([
+  const [author, comments, likes, event, mediaFiles] = await Promise.all([
     ctx.db.get(post.authorId),
     getThreadedCommentsByPost(ctx, post._id),
     ctx.db
@@ -88,6 +91,7 @@ async function serializeEventFeedPost(
       .withIndex('by_postId', (q) => q.eq('postId', post._id))
       .collect(),
     post.eventId ? ctx.db.get(post.eventId) : Promise.resolve(null),
+    serializeStorageFiles(ctx, mediaIds),
   ]);
 
   return {
@@ -101,6 +105,7 @@ async function serializeEventFeedPost(
     likes: post.likeCount ?? likes.length,
     liked: viewerId ? likes.some((like) => like.userId === viewerId) : false,
     mediaIds,
+    mediaFiles,
     eventId: post.eventId ?? null,
     eventName: event?.name ?? '',
     commentCount: countComments(comments),
@@ -186,8 +191,7 @@ export const getTopMediaPosts = query({
 
     return await Promise.all(
       topPosts.map(async (post) => {
-        // check if the view has liked the post
-        const [author, like] = await Promise.all([
+        const [author, like, thumbnailFile] = await Promise.all([
           ctx.db.get(post.authorId),
           guestMode
             ? Promise.resolve(null)
@@ -197,12 +201,16 @@ export const getTopMediaPosts = query({
                   q.eq('userId', viewer._id).eq('postId', post._id)
                 )
                 .unique(),
+          post.mediaIds?.[0] != null
+            ? serializeStorageFile(ctx, post.mediaIds[0])
+            : Promise.resolve(null),
         ]);
 
         return {
           id: post._id,
           caption: post.caption ?? '',
           mediaIds: post.mediaIds,
+          thumbnailFile,
           likeCount: post.likeCount ?? 0,
           liked: like !== null,
           matchedTagCount: 0,

--- a/packages/backend/convex/files.ts
+++ b/packages/backend/convex/files.ts
@@ -20,6 +20,10 @@ export async function serializeStorageFile(ctx: QueryCtx, storageId: Id<'_storag
   };
 }
 
+export async function serializeStorageFiles(ctx: QueryCtx, storageIds: Array<Id<'_storage'>>) {
+  return await Promise.all(storageIds.map((id) => serializeStorageFile(ctx, id)));
+}
+
 export const generateUploadUrl = mutation({
   args: {},
   handler: async (ctx) => {

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -9,6 +9,7 @@ import {
   __backend_only_guestOrAuthenticatedUser,
 } from './auth';
 import { getThreadedCommentsByPost } from './comments';
+import { serializeStorageFiles } from './files';
 import { getHiddenUserIds } from './moderation/block';
 import { getHiddenPostIds } from './moderation/report';
 import { getAvatarUrlForUser, getDisplayNameForUser, getUsernameForUser } from './user_identity';
@@ -326,7 +327,8 @@ async function serializeProfileFeedPost(
   post: Doc<'posts'>,
   viewerId?: Doc<'users'>['_id']
 ) {
-  const [author, comments, likes, event] = await Promise.all([
+  const mediaIds = post.mediaIds ?? [];
+  const [author, comments, likes, event, mediaFiles] = await Promise.all([
     ctx.db.get(post.authorId),
     getThreadedCommentsByPost(ctx, post._id),
     ctx.db
@@ -334,6 +336,7 @@ async function serializeProfileFeedPost(
       .withIndex('by_postId', (q) => q.eq('postId', post._id))
       .collect(),
     post.eventId ? ctx.db.get(post.eventId) : Promise.resolve(null),
+    serializeStorageFiles(ctx, mediaIds),
   ]);
 
   return {
@@ -346,7 +349,8 @@ async function serializeProfileFeedPost(
     authorAvatarUrl: getAvatarUrlForUser(author),
     likes: post.likeCount ?? likes.length,
     liked: viewerId ? likes.some((like) => like.userId === viewerId) : false,
-    mediaIds: post.mediaIds ?? [],
+    mediaIds,
+    mediaFiles,
     eventId: post.eventId ?? null,
     eventName: event?.name ?? '',
     commentCount: countComments(comments),


### PR DESCRIPTION
## Summary

Moves Convex storage file URL resolution from individual client-side useQuery(api.files.getFile) calls to server-side serializers. Media URLs and file metadata are now resolved in batch and returned as part of the parent query response, eliminating a large number of redundant WebSocket subscriptions.

---

## Why is this change necessary?

Each component that rendered media (map markers, feed cards, profile grids, search results, top moments) independently subscribed to api.files.getFile per storage ID. On a feed with many posts and multiple media items each, this created N×M concurrent Convex subscriptions — the root cause of the ~1.4GB bandwidth spike observed in production. Resolving URLs server-side consolidates this into the parent query, so no separate file subscriptions are needed on the client.

---

## Changes

- Added serializeStorageFiles helper to files.ts — a Promise.all wrapper over serializeStorageFile for batching multiple IDs
- serializeEvent now resolves mediaUrl server-side and includes it in the event payload
- serializeEventFeedPost and serializeProfileFeedPost now resolve mediaFiles (url + isVideo) for all post media server-side
- getTopMediaPosts now resolves thumbnailFile in parallel with author/like fetches (single Promise.all)
- Removed useQuery(api.files.getFile) from: EventMarker, EventSearchImage, MediaTile, MediaItem, MediaGridItem, EventMediaTile, and the event detail page
- Props updated throughout: mediaId → mediaUrl, mediaId → mediaUrl, mediaIds → mediaFiles, thumbnailId → thumbnailFile

---